### PR TITLE
Reserve kernel from frame allocator

### DIFF
--- a/kernel/arch/x86_64/kernel/mbi.cpp
+++ b/kernel/arch/x86_64/kernel/mbi.cpp
@@ -22,8 +22,8 @@
 extern "C" {
 extern multiboot::Mbi *mbiPointer;
 
-extern void* kernelPhysicalAddress[0];
-extern void* kernelPhysicalEnd[0];
+extern void *kernelPhysicalAddress[0];
+extern void *kernelPhysicalEnd[0];
 }
 
 namespace memory {
@@ -66,7 +66,9 @@ static void parseMemoryMapTag(MemoryMapTag *memoryMap) {
       memory::physicalMemory.addBlock(memory::Block(entryBase, entryEnd));
     }
   }
-  memory::physicalMemory.reserve(memory::Block((void*)PAGE_ALIGN_DOWN((size_t)kernelPhysicalAddress), (void*)PAGE_ALIGN_UP((size_t)kernelPhysicalEnd)));
+  memory::physicalMemory.reserve(
+      memory::Block((void *)PAGE_ALIGN_DOWN((size_t)kernelPhysicalAddress),
+                    (void *)PAGE_ALIGN_UP((size_t)kernelPhysicalEnd)));
 }
 static void parseFrameBufferTag(FrameBufferTag *tag) {
   display::frameBuffer.pointer = (uint8_t *)tag->address;

--- a/kernel/arch/x86_64/kernel/mbi.cpp
+++ b/kernel/arch/x86_64/kernel/mbi.cpp
@@ -21,6 +21,9 @@
 
 extern "C" {
 extern multiboot::Mbi *mbiPointer;
+
+extern void* kernelPhysicalAddress[0];
+extern void* kernelPhysicalEnd[0];
 }
 
 namespace memory {
@@ -63,6 +66,7 @@ static void parseMemoryMapTag(MemoryMapTag *memoryMap) {
       memory::physicalMemory.addBlock(memory::Block(entryBase, entryEnd));
     }
   }
+  memory::physicalMemory.reserve(memory::Block((void*)PAGE_ALIGN_DOWN((size_t)kernelPhysicalAddress), (void*)PAGE_ALIGN_UP((size_t)kernelPhysicalEnd)));
 }
 static void parseFrameBufferTag(FrameBufferTag *tag) {
   display::frameBuffer.pointer = (uint8_t *)tag->address;

--- a/kernel/memory/memoryBlock.cpp
+++ b/kernel/memory/memoryBlock.cpp
@@ -64,6 +64,34 @@ void *BlockMap::allocate(size_t amount) {
   }
   return nullptr; // Not enough room in the block map
 }
+void BlockMap::reserve(Block blockToRemove) {
+  size_t blockToRemoveStart = (size_t)blockToRemove.getStart();
+  size_t blockToRemoveEnd = (size_t)blockToRemove.getEnd();
+  for (unsigned i = 0; i < numBlocks; i++) {
+    Block &currentBlock = blocks[i];
+    size_t currentBlockStart = (size_t)currentBlock.getStart();
+    size_t currentBlockEnd = (size_t)currentBlock.getEnd();
+    if (currentBlockStart >= blockToRemoveEnd) {
+      continue;
+    } else if (currentBlockEnd <= blockToRemoveStart) {
+      continue;
+    } else if (currentBlockStart >= blockToRemoveStart &&
+               currentBlockEnd <=
+                   blockToRemoveEnd) { // currentBlock is inside blockToRemove
+      currentBlock = Block();
+    } else { // There is some intersection between the blocks
+    if (currentBlockStart >= blockToRemoveStart) {
+      currentBlock.start = blockToRemove.end;
+    }else if (currentBlockEnd <= blockToRemoveEnd) {
+      currentBlock.start = blockToRemove.end;
+    }else { // blockToRemove is entirely inside currentBlock
+      currentBlock = Block();
+      addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveEnd));
+      addBlock(Block((void *)blockToRemoveEnd, (void *)currentBlockEnd));
+    }
+    }
+  }
+}
 
 void BlockBuffer::addBlock(Block block) {
   if (numBlocks < BLOCK_BUFFER_SIZE) {

--- a/kernel/memory/memoryBlock.cpp
+++ b/kernel/memory/memoryBlock.cpp
@@ -67,6 +67,7 @@ void *BlockMap::allocate(size_t amount) {
 void BlockMap::reserve(Block blockToRemove) {
   size_t blockToRemoveStart = (size_t)blockToRemove.getStart();
   size_t blockToRemoveEnd = (size_t)blockToRemove.getEnd();
+  merge();
   for (unsigned i = 0; i < numBlocks; i++) {
     Block &currentBlock = blocks[i];
     size_t currentBlockStart = (size_t)currentBlock.getStart();
@@ -83,10 +84,10 @@ void BlockMap::reserve(Block blockToRemove) {
     if (currentBlockStart >= blockToRemoveStart) {
       currentBlock.start = blockToRemove.end;
     }else if (currentBlockEnd <= blockToRemoveEnd) {
-      currentBlock.start = blockToRemove.end;
+      currentBlock.end = blockToRemove.start;
     }else { // blockToRemove is entirely inside currentBlock
       currentBlock = Block();
-      addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveEnd));
+      addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveStart));
       addBlock(Block((void *)blockToRemoveEnd, (void *)currentBlockEnd));
     }
     }

--- a/kernel/memory/memoryBlock.cpp
+++ b/kernel/memory/memoryBlock.cpp
@@ -81,15 +81,15 @@ void BlockMap::reserve(Block blockToRemove) {
                    blockToRemoveEnd) { // currentBlock is inside blockToRemove
       currentBlock = Block();
     } else { // There is some intersection between the blocks
-    if (currentBlockStart >= blockToRemoveStart) {
-      currentBlock.start = blockToRemove.end;
-    }else if (currentBlockEnd <= blockToRemoveEnd) {
-      currentBlock.end = blockToRemove.start;
-    }else { // blockToRemove is entirely inside currentBlock
-      currentBlock = Block();
-      addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveStart));
-      addBlock(Block((void *)blockToRemoveEnd, (void *)currentBlockEnd));
-    }
+      if (currentBlockStart >= blockToRemoveStart) {
+        currentBlock.start = blockToRemove.end;
+      } else if (currentBlockEnd <= blockToRemoveEnd) {
+        currentBlock.end = blockToRemove.start;
+      } else { // blockToRemove is entirely inside currentBlock
+        currentBlock = Block();
+        addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveStart));
+        addBlock(Block((void *)blockToRemoveEnd, (void *)currentBlockEnd));
+      }
     }
   }
 }

--- a/kernel/memory/memoryBlock_test.cpp
+++ b/kernel/memory/memoryBlock_test.cpp
@@ -54,6 +54,13 @@ bool blockMapTest(::test::Logger logger) {
     }
   }
   logger("blockMapTest: Passed stress tester\n");
+  // Reserve test
+  map.reserve(Block((void *)0x1000, (void *)0x3000)); // Reserve the whole map
+  if (map.allocate(1) != nullptr) {
+    logger("blockMapTest failed: reserving memory failed");
+    return false;
+  }
+  logger("blockMapTest: Passed reserve test");
   logger("blockMapTest: Succeeded\n");
   return true;
 }

--- a/kernel/memory/memoryBlock_test.cpp
+++ b/kernel/memory/memoryBlock_test.cpp
@@ -85,7 +85,7 @@ bool blockMapTest(::test::Logger logger) {
   }
   if (map.allocate(1) != nullptr) {
     logger("blockMapTest failed: Excess memory in the block after reserving in "
-           "the middle");
+           "the middle\n");
     return false;
   }
   logger("blockMapTest: Passed reserve test");

--- a/kernel/memory/memoryBlock_test.cpp
+++ b/kernel/memory/memoryBlock_test.cpp
@@ -83,6 +83,11 @@ bool blockMapTest(::test::Logger logger) {
     logger("blockMapTest failed: Reserving in the middle of a block failed\n");
     return false;
   }
+  if (map.allocate(1) != nullptr) {
+    logger("blockMapTest failed: Excess memory in the block after reserving in "
+           "the middle");
+    return false;
+  }
   logger("blockMapTest: Passed reserve test");
   logger("blockMapTest: Succeeded\n");
   return true;

--- a/kernel/memory/memoryBlock_test.cpp
+++ b/kernel/memory/memoryBlock_test.cpp
@@ -54,10 +54,33 @@ bool blockMapTest(::test::Logger logger) {
     }
   }
   logger("blockMapTest: Passed stress tester\n");
+  map = BlockMap();
   // Reserve test
   map.reserve(Block((void *)0x1000, (void *)0x3000)); // Reserve the whole map
   if (map.allocate(1) != nullptr) {
-    logger("blockMapTest failed: reserving memory failed");
+    logger("blockMapTest failed: reserving memory failed\n");
+    return false;
+  }
+  map.addBlock(Block((void *)0x1000, (void *)0x3000));
+  map.reserve(Block((void *)0x1000, (void *)0x2000));
+  if (map.allocate(0x1000) != (void *)0x2000) {
+    logger("blockMapTest failed: Reserving from the start of a block failed\n");
+    return false;
+  }
+  map.addBlock(Block((void *)0x1000, (void *)0x3000));
+  map.reserve(Block((void *)0x1800, (void *)0x2800));
+  if (map.allocate(0x1000) != nullptr) {
+    logger("blockMapTest failed: Reserving the middle of a block "
+           "failed\n");
+    return false;
+  }
+  if (map.allocate(0x800) != (void *)0x1000) {
+    logger(
+        "blockMapTest failed: Reserving in the middle of the block failed\n");
+    return false;
+  }
+  if (map.allocate(0x800) != (void *)0x2800) {
+    logger("blockMapTest failed: Reserving in the middle of a block failed\n");
     return false;
   }
   logger("blockMapTest: Passed reserve test");

--- a/kernel/memory/memoryBlock_test.cpp
+++ b/kernel/memory/memoryBlock_test.cpp
@@ -88,7 +88,7 @@ bool blockMapTest(::test::Logger logger) {
            "the middle\n");
     return false;
   }
-  logger("blockMapTest: Passed reserve test");
+  logger("blockMapTest: Passed reserve test\n");
   logger("blockMapTest: Succeeded\n");
   return true;
 }

--- a/kernel/test/test.cpp
+++ b/kernel/test/test.cpp
@@ -34,7 +34,7 @@ bool runTests(Logger logger) {
   }
   logger("All tests passed\n");
 #else
-  logger("---Skipping tests: not a debug build\n");
+  logger("Skipping tests: not a debug build\n");
 #endif
   return true;
 }

--- a/kernel/test/test.cpp
+++ b/kernel/test/test.cpp
@@ -33,6 +33,8 @@ bool runTests(Logger logger) {
     }
   }
   logger("All tests passed\n");
+#else
+  logger("---Skipping tests: not a debug build\n");
 #endif
   return true;
 }


### PR DESCRIPTION
This stops the kernel from being allowed to be overwritten by the physical memory allocator.

The multiboot2 specification says that the memory map will still mark the kernel, boot modules and mbi structure as usable. This is not ideal as it means the kernel has to manually remove itself from the memory map if it wants to remain.

Mykonos now does this using a reserve function on the BlockMap.