### PR TITLE
Allow infinite memory allocations

### DIFF
--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -138,5 +138,5 @@ gdt_end:
 .bss
 
 initial_stack:
-.fill 16384 /*Should be fine*/
+.fill 65536 /*Should be fine*/
 initial_stack_top:

--- a/kernel/include/memoryBlock.h
+++ b/kernel/include/memoryBlock.h
@@ -65,17 +65,6 @@ public:
   }
   void reserve(Block block);
 };
-#define BLOCK_BUFFER_SIZE 256
-class BlockBuffer {
-private:
-  Block blocks[BLOCK_BUFFER_SIZE];
-  unsigned numBlocks = 0;
-
-public:
-  void addBlock(Block block);
-  Block removeBlock(void *startAddress);
-};
-
 } // namespace memory
 
 #endif

--- a/kernel/include/memoryBlock.h
+++ b/kernel/include/memoryBlock.h
@@ -75,24 +75,7 @@ public:
   void addBlock(Block block);
   Block removeBlock(void *startAddress);
 };
-class BlockAllocator {
-private:
-  BlockBuffer allocated;
-  BlockMap &freeMemory;
 
-public:
-  BlockAllocator(BlockMap &freeMemory) : freeMemory(freeMemory) {}
-  void *allocate(size_t amount) {
-    void *result = freeMemory.allocate(amount);
-    allocated.addBlock(Block(result, (void *)((uint8_t *)result + amount)));
-    return result;
-  }
-  size_t free(void *ptr) {
-    size_t size = allocated.removeBlock(ptr).capacity();
-    freeMemory.returnMemory(ptr, size);
-    return size;
-  }
-};
 } // namespace memory
 
 #endif

--- a/kernel/include/virtualMemory.h
+++ b/kernel/include/virtualMemory.h
@@ -20,7 +20,7 @@
 #include <memoryBlock.h>
 
 namespace memory {
-extern BlockAllocator virtualMemory;
+extern BlockMap virtualMemory;
 }
 
 #endif

--- a/kernel/memory/Make.steps
+++ b/kernel/memory/Make.steps
@@ -1,4 +1,4 @@
 STEPS+=memory/memoryBlock.o memory/virtualMemory.o memory/kmalloc.o
 STEPS+=memory/string.o
 
-TEST_STEPS+=memory/memoryBlock_test.o
+TEST_STEPS+=memory/memoryBlock_test.o memory/kmalloc_test.o

--- a/kernel/memory/kmalloc_test.cpp
+++ b/kernel/memory/kmalloc_test.cpp
@@ -35,7 +35,7 @@ bool kmallocTest(::test::Logger logger) {
       break;
     }
   }
-  // Yes, clean up
+  // Clean up
   for (int i = 0; i < numAllocated; i++) {
     kfree(allocatedMemory[i]);
   }

--- a/kernel/memory/kmalloc_test.cpp
+++ b/kernel/memory/kmalloc_test.cpp
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 2021  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifdef RUNTIME_TESTS
+
+#include <kmalloc.h>
+#include <test.h>
+
+namespace memory {
+namespace test {
+bool kmallocTest(::test::Logger logger) {
+  logger("kmallocTest:\n");
+  // Stress test: can it allocate forever?
+  void *allocatedMemory[2048];
+  bool passed = true;
+  int numAllocated = 0;
+  for (int i = 0; i < 2048; i++) {
+    allocatedMemory[i] = kmalloc(2);
+    numAllocated++;
+    if (allocatedMemory[i] == nullptr) {
+      passed = false;
+      break;
+    }
+  }
+  // Yes, clean up
+  for (int i = 0; i < numAllocated; i++) {
+    kfree(allocatedMemory[i]);
+  }
+  if (!passed) {
+    logger("kmallocTest: Failed stress test\n");
+    return false;
+  }
+  logger("kmallocTest: Passed stress test\n");
+  logger("kmallocTest: Succeeded\n");
+  return true;
+}
+ADD_TEST(kmallocTest);
+} // namespace test
+} // namespace memory
+
+#endif

--- a/kernel/memory/memoryBlock.cpp
+++ b/kernel/memory/memoryBlock.cpp
@@ -93,27 +93,4 @@ void BlockMap::reserve(Block blockToRemove) {
     }
   }
 }
-
-void BlockBuffer::addBlock(Block block) {
-  if (numBlocks < BLOCK_BUFFER_SIZE) {
-    blocks[numBlocks++] = block;
-  }
-}
-Block BlockBuffer::removeBlock(void *startAddress) {
-  unsigned i;
-  Block block;
-  // Find the block
-  for (i = 0; i < numBlocks; i++) {
-    if (blocks[i].getStart() == startAddress) {
-      block = blocks[i];
-      break;
-    }
-  }
-  // Push everything after this one down
-  for (i++; i < numBlocks; i++) {
-    blocks[i - 1] = blocks[i];
-  }
-  numBlocks--;
-  return block;
-}
 } // namespace memory

--- a/kernel/memory/virtualMemory.cpp
+++ b/kernel/memory/virtualMemory.cpp
@@ -24,9 +24,8 @@ extern char kernelHeapStart, kernelHeapEnd;
 }
 
 namespace memory {
-static BlockMap virtualMemoryMap;
-BlockAllocator virtualMemory(virtualMemoryMap);
+BlockMap virtualMemory;
 __attribute__((constructor)) static void initVirtualMemory() {
-  virtualMemoryMap.addBlock(Block(&kernelHeapStart, &kernelHeapEnd));
+  virtualMemory.addBlock(Block(&kernelHeapStart, &kernelHeapEnd));
 }
 } // namespace memory


### PR DESCRIPTION
This replaces the floored method previously used for keeping track of blocks of memory allocated by kmalloc. This used a fixed length array of blocks, which would not have worked very well with more than 256 (BLOCK_BUFFER_SIZE) allocations.

The new system uses a header at the beginnning of each allocated region of memory, which holds the size of that allocation.