### PR TITLE
Create exception handler

### DIFF
--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -2,3 +2,4 @@ STEPS+=arch/x86_64/bootstrap/multiboot.o arch/x86_64/bootstrap/bootstrap.o
 STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/pageTableInit.o
 STEPS+=arch/x86_64/kernel/paging/paging.o
 STEPS+=arch/x86_64/kernel/memory/copying.o
+STEPS+=arch/x86_64/kernel/interrupts/interrupts.o

--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -2,4 +2,4 @@ STEPS+=arch/x86_64/bootstrap/multiboot.o arch/x86_64/bootstrap/bootstrap.o
 STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/pageTableInit.o
 STEPS+=arch/x86_64/kernel/paging/paging.o
 STEPS+=arch/x86_64/kernel/memory/copying.o
-STEPS+=arch/x86_64/kernel/interrupts/interrupts.o
+STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/interruptHandlers.o

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -127,6 +127,8 @@ gdt_pointer:
 .word gdt_end - gdt - 1 /*Size - 1*/
 .quad gdt /*Pointer*/
 
+.section .rodata, "a"
+
 gdt:
 .quad 0 /*The first descriptor must be null*/
 .quad GDT_PRESENT | GDT_LONG | GDT_NOT_SYSTEM | GDT_EXECUTABLE /*Kernel code segment*/

--- a/kernel/arch/x86_64/include/idt.h
+++ b/kernel/arch/x86_64/include/idt.h
@@ -1,0 +1,44 @@
+/*
+    Copyright (C) 2021  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _IDT_H
+#define _IDT_H
+
+#include <stdint.h>
+
+namespace interrupts {
+struct IdtEntry __attribute__((packed)) {
+  uint16_t offsetLow; // 15:0
+  uint16_t gdtSelector;
+  uint8_t istEntry; // 3-bit interrupt stack table number
+  uint8_t type : 4; // 0xE = interrupt gate, 0xF = trap gate
+  uint8_t zero : 1; // Must be zero
+  uint8_t privilege : 2;
+  uint8_t present;
+  uint16_t offsetMiddle; // 31:16
+  uint32_t offsetHigh;   // 63:32
+  uint32_t reserved;
+};
+static_assert(sizeof(IdtEntry) == 16, "IdtEntry must be 16 bytes");
+
+struct IdtPointer __attribute__((packed)) {
+  uint16_t limit; // size - 1
+  IdtEntry *pointer;
+};
+static_assert(sizeof(IdtPointer) == 10, "IdtPointer must be 10 bytes");
+} // namespace interrupts
+
+#endif

--- a/kernel/arch/x86_64/include/idt.h
+++ b/kernel/arch/x86_64/include/idt.h
@@ -33,7 +33,8 @@ struct IdtEntry {
   uint32_t reserved;
 
   IdtEntry() {}
-  IdtEntry(void (*function)(), int istNum, bool trap) : gdtSelector(8), istEntry(istNum), type(trap ? 0xF : 0xE), present(1) {
+  IdtEntry(void (*function)(), int istNum, bool trap)
+      : gdtSelector(8), istEntry(istNum), type(trap ? 0xF : 0xE), present(1) {
     uint64_t functionPointer = (uint64_t)function;
     offsetLow = functionPointer & 0xFFFF;
     functionPointer >>= 16;

--- a/kernel/arch/x86_64/include/idt.h
+++ b/kernel/arch/x86_64/include/idt.h
@@ -31,6 +31,16 @@ struct IdtEntry {
   uint16_t offsetMiddle; // 31:16
   uint32_t offsetHigh;   // 63:32
   uint32_t reserved;
+
+  IdtEntry() {}
+  IdtEntry(void (*function)(), int istNum, bool trap) : gdtSelector(8), istEntry(istNum), type(trap ? 0xF : 0xE), present(1) {
+    uint64_t functionPointer = (uint64_t)function;
+    offsetLow = functionPointer & 0xFFFF;
+    functionPointer >>= 16;
+    offsetMiddle = functionPointer & 0xFFFF;
+    functionPointer >>= 16;
+    offsetHigh = functionPointer;
+  }
 } __attribute__((packed));
 static_assert(sizeof(IdtEntry) == 16, "IdtEntry must be 16 bytes");
 

--- a/kernel/arch/x86_64/include/idt.h
+++ b/kernel/arch/x86_64/include/idt.h
@@ -20,24 +20,24 @@
 #include <stdint.h>
 
 namespace interrupts {
-struct IdtEntry __attribute__((packed)) {
+struct IdtEntry {
   uint16_t offsetLow; // 15:0
   uint16_t gdtSelector;
   uint8_t istEntry; // 3-bit interrupt stack table number
   uint8_t type : 4; // 0xE = interrupt gate, 0xF = trap gate
   uint8_t zero : 1; // Must be zero
   uint8_t privilege : 2;
-  uint8_t present;
+  uint8_t present : 1;
   uint16_t offsetMiddle; // 31:16
   uint32_t offsetHigh;   // 63:32
   uint32_t reserved;
-};
+} __attribute__((packed));
 static_assert(sizeof(IdtEntry) == 16, "IdtEntry must be 16 bytes");
 
-struct IdtPointer __attribute__((packed)) {
+struct IdtPointer {
   uint16_t limit; // size - 1
   IdtEntry *pointer;
-};
+} __attribute__((packed));
 static_assert(sizeof(IdtPointer) == 10, "IdtPointer must be 10 bytes");
 } // namespace interrupts
 

--- a/kernel/arch/x86_64/include/interrupts.h
+++ b/kernel/arch/x86_64/include/interrupts.h
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 2021  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _INTERRUPTS_H
+#define _INTERRUPTS_H
+
+namespace interrupts {
+void init();
+}
+
+#endif

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -15,6 +15,55 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+.macro errorCodeExceptionHandler number
+.section .text.interruptHandlers, "ax"
+1:
+pushq $\number
+jmp genericExceptionHandler
+.section .rodata.interruptHandlers, "a"
+.quad 1b
+.endm
+
+.macro noErrorCodeExceptionHandler number
+.section .text.interruptHandlers, "ax"
+1:
+pushq $0 /*Fake exception code*/
+pushq $\number
+jmp genericExceptionHandler
+.section .rodata.interruptHandlers, "a"
+.quad 1b
+.endm
+
+.section .rodata.interruptHandlers, "a"
+.globl idtFunctions
+idtFunctions:
+
+noErrorCodeExceptionHandler 0 /*#DE: divide by 0*/
+noErrorCodeExceptionHandler 1 /*#DB: debug*/
+noErrorCodeExceptionHandler 2 /*#NMI: Non-maskable interrupt*/
+noErrorCodeExceptionHandler 3 /*#BP: Breakpoint*/
+noErrorCodeExceptionHandler 4 /*#OF: Overflow*/
+noErrorCodeExceptionHandler 5 /*#BR: Bound range exceeded*/
+noErrorCodeExceptionHandler 6 /*#OF: Invalid opcode*/
+noErrorCodeExceptionHandler 7 /*#NM: Device not available*/
+errorCodeExceptionHandler 8 /*#DF: Double fault*/
+/*Skip 9*/
+errorCodeExceptionHandler 10 /*#TS: Invalid tss*/
+errorCodeExceptionHandler 11 /*#NP: Segment not present*/
+errorCodeExceptionHandler 12 /*#SS: Stack exception*/
+errorCodeExceptionHandler 14 /*#GP: General protection fault*/
+errorCodeExceptionHandler 14 /*#PF: Page fault*/
+noErrorCodeExceptionHandler 16 /*#MF: X87 FPU exception*/
+errorCodeExceptionHandler 17 /*#AC: Alignment check exception*/
+noErrorCodeExceptionHandler 18 /*#MC: Machine check*/
+noErrorCodeExceptionHandler 19 /*#XF: SSE exception*/
+/*Skip 20*/
+errorCodeExceptionHandler 21 /*#CP: Control transfer exception*/
+/*Skip a few*/
+noErrorCodeExceptionHandler 28 /*#HV: Hypervisor injection exception*/
+errorCodeExceptionHandler 29 /*#VC: VMM communication error*/
+errorCodeExceptionHandler 30 /*#SX: Security exception*/
+
 currentInterruptNumber = 32
 .rept 256 - 32 /*Number of real (non-exception) interrupts*/
 .section .text.interruptHandlers, "ax"
@@ -32,3 +81,7 @@ currentInterruptNumber = currentInterruptNumber + 1
 genericInterruptHandler:
 addq $8, %rsp
 iretq
+genericExceptionHandler:
+cli
+1: hlt
+jmp 1b

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -34,6 +34,12 @@ jmp genericExceptionHandler
 .quad 1b
 .endm
 
+.macro reservedExceptions count=1
+.rep \count
+errorCodeExceptionHandler -1
+.endr
+.endm
+
 .section .rodata.interruptHandlers, "a"
 .globl idtFunctions
 idtFunctions:
@@ -47,7 +53,7 @@ noErrorCodeExceptionHandler 5 /*#BR: Bound range exceeded*/
 noErrorCodeExceptionHandler 6 /*#OF: Invalid opcode*/
 noErrorCodeExceptionHandler 7 /*#NM: Device not available*/
 errorCodeExceptionHandler 8 /*#DF: Double fault*/
-/*Skip 9*/
+reservedExceptions 1
 errorCodeExceptionHandler 10 /*#TS: Invalid tss*/
 errorCodeExceptionHandler 11 /*#NP: Segment not present*/
 errorCodeExceptionHandler 12 /*#SS: Stack exception*/
@@ -57,12 +63,13 @@ noErrorCodeExceptionHandler 16 /*#MF: X87 FPU exception*/
 errorCodeExceptionHandler 17 /*#AC: Alignment check exception*/
 noErrorCodeExceptionHandler 18 /*#MC: Machine check*/
 noErrorCodeExceptionHandler 19 /*#XF: SSE exception*/
-/*Skip 20*/
+reservedExceptions 1
 errorCodeExceptionHandler 21 /*#CP: Control transfer exception*/
-/*Skip a few*/
+reservedExceptions 7
 noErrorCodeExceptionHandler 28 /*#HV: Hypervisor injection exception*/
 errorCodeExceptionHandler 29 /*#VC: VMM communication error*/
 errorCodeExceptionHandler 30 /*#SX: Security exception*/
+reservedExceptions 1
 
 currentInterruptNumber = 32
 .rept 256 - 32 /*Number of real (non-exception) interrupts*/

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -14,16 +14,21 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <idt.h>
-#include <interrupts.h>
 
-typedef void (*InterruptHandlerFunction)();
+currentInterruptNumber = 32
+.rept 256 - 32 /*Number of real (non-exception) interrupts*/
+.section .text.interruptHandlers, "ax"
+1:
+pushq $currentInterruptNumber
+jmp genericInterruptHandler
 
-extern "C" {
-extern InterruptHandlerFunction idtFunctions[256];
-}
+.section .rodata.interruptHandlers, "a"
+.quad 1b
 
-namespace interrupts {
-static IdtEntry idt[256];
-static IdtPointer idtPointer;
-} // namespace interrupts
+currentInterruptNumber = currentInterruptNumber + 1
+.endr
+
+.section .text.interruptHandlers, "ax"
+genericInterruptHandler:
+addq $8, %rsp
+iretq

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -50,7 +50,7 @@ noErrorCodeExceptionHandler 2 /*#NMI: Non-maskable interrupt*/
 noErrorCodeExceptionHandler 3 /*#BP: Breakpoint*/
 noErrorCodeExceptionHandler 4 /*#OF: Overflow*/
 noErrorCodeExceptionHandler 5 /*#BR: Bound range exceeded*/
-noErrorCodeExceptionHandler 6 /*#OF: Invalid opcode*/
+noErrorCodeExceptionHandler 6 /*#UD: Invalid opcode*/
 noErrorCodeExceptionHandler 7 /*#NM: Device not available*/
 errorCodeExceptionHandler 8 /*#DF: Double fault*/
 reservedExceptions 1

--- a/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
+++ b/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
@@ -1,0 +1,18 @@
+/*
+    Copyright (C) 2021  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <interrupts.h>
+#include <idt.h>

--- a/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
+++ b/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
@@ -28,9 +28,12 @@ static IdtEntry idt[256];
 static IdtPointer idtPointer;
 void init() {
   for (int i = 0; i < 256; i++) {
-    idt[i] =
-        IdtEntry(idtFunctions[i], 0,
-                 i < 32); // First 32 are traps (exceptions), the rest are interrupts
+    idt[i] = IdtEntry(
+        idtFunctions[i], 0,
+        i < 32); // First 32 are traps (exceptions), the rest are interrupts
   }
+  idtPointer.pointer = idt;
+  idtPointer.limit = sizeof(idt) - 1;
+  __asm__ volatile("lidt %0" : : "m"(idtPointer) : "memory");
 }
 } // namespace interrupts

--- a/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
+++ b/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
@@ -26,4 +26,11 @@ extern InterruptHandlerFunction idtFunctions[256];
 namespace interrupts {
 static IdtEntry idt[256];
 static IdtPointer idtPointer;
+void init() {
+  for (int i = 0; i < 256; i++) {
+    idt[i] =
+        IdtEntry(idtFunctions[i], 0,
+                 i < 32); // First 32 are traps (exceptions), the rest are interrupts
+  }
+}
 } // namespace interrupts

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -23,6 +23,8 @@
 
 #include <test.h>
 
+#include <interrupts.h>
+
 typedef void (*ConstructorOrDestructor)();
 
 extern "C" {
@@ -44,7 +46,9 @@ extern "C" [[noreturn]] void kstart() {
   kout::print("Initialised the console\n\n");
   if (test::runTests(kout::print)) {
     // Continue
-    kout::print(10203ul);
+    interrupts::init();
+    kout::print("Installed interrupt handlers\n");
+    __asm__ volatile("int $0xFF");
   } else {
     // The tests failed! Abort
   }

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -48,7 +48,6 @@ extern "C" [[noreturn]] void kstart() {
     // Continue
     interrupts::init();
     kout::print("Installed interrupt handlers\n");
-    __asm__ volatile("int $0xFF");
   } else {
     // The tests failed! Abort
   }


### PR DESCRIPTION
This creates an IDT (Interrupt Descriptor Table) for handling interrupts and exceptions. The interrupts and exceptions get routed to a generic handler, after pushing their interrupt or exception number to the stack.

Currently, these handlers do nothing useful, but they will be used later for handling the interrupts properly.