### PR TITLE
Call kpanic during exceptions

### DIFF
--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -3,3 +3,4 @@ STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/
 STEPS+=arch/x86_64/kernel/paging/paging.o
 STEPS+=arch/x86_64/kernel/memory/copying.o
 STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/interruptHandlers.o
+STEPS+=arch/x86_64/kernel/exceptions/exceptionHandlers.o

--- a/kernel/arch/x86_64/include/cpuExceptions.h
+++ b/kernel/arch/x86_64/include/cpuExceptions.h
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2021  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _CPU_EXCEPTIONS_H
+#define _CPU_EXCEPTIONS_H
+
+#define CPU_DE 0 /*Division exception*/
+#define CPU_DB 1 /*Debug*/
+#define CPU_NMI 2 /*Non-Maskable Interrupt*/
+#define CPU_BP 3  /*Breakpoint*/
+#define CPU_OF 4 /*Overflow exception*/
+#define CPU_BR 5 /*Bound Range exception*/
+#define CPU_UD 6 /*Invalid opcode*/
+#define CPU_NM 7 /*Device not available*/
+#define CPU_DF 8 /*Double fault*/
+#define CPU_TS 10 /*Invalid TSS*/
+#define CPU_NP 11 /*Segment Not Present*/
+#define CPU_SS 12 /*Stack exception*/
+#define CPU_GP 13 /*General Protection Fault*/
+#define CPU_PF 14 /*Page Fault*/
+#define CPU_MF 16 /*X87 FPU exception*/
+#define CPU_AC 17 /*Alignment Check exception*/
+#define CPU_MC 18 /*Machine Check*/
+#define CPU_XF 19 /*SSE exception*/
+#define CPU_CP 21 /*Control transfer exception*/
+#define CPU_HV 28 /*Hyper Visor injection exception*/
+#define CPU_VC 29 /*VMM Communication exception*/
+#define CPU_SX 30 /*Security exception*/
+
+#define CPU_UNKNOWN -1 /*Unknown/invalid exception*/
+
+#endif

--- a/kernel/arch/x86_64/include/cpuExceptions.h
+++ b/kernel/arch/x86_64/include/cpuExceptions.h
@@ -17,15 +17,15 @@
 #ifndef _CPU_EXCEPTIONS_H
 #define _CPU_EXCEPTIONS_H
 
-#define CPU_DE 0 /*Division exception*/
-#define CPU_DB 1 /*Debug*/
+#define CPU_DE 0  /*Division exception*/
+#define CPU_DB 1  /*Debug*/
 #define CPU_NMI 2 /*Non-Maskable Interrupt*/
 #define CPU_BP 3  /*Breakpoint*/
-#define CPU_OF 4 /*Overflow exception*/
-#define CPU_BR 5 /*Bound Range exception*/
-#define CPU_UD 6 /*Invalid opcode*/
-#define CPU_NM 7 /*Device not available*/
-#define CPU_DF 8 /*Double fault*/
+#define CPU_OF 4  /*Overflow exception*/
+#define CPU_BR 5  /*Bound Range exception*/
+#define CPU_UD 6  /*Invalid opcode*/
+#define CPU_NM 7  /*Device not available*/
+#define CPU_DF 8  /*Double fault*/
 #define CPU_TS 10 /*Invalid TSS*/
 #define CPU_NP 11 /*Segment Not Present*/
 #define CPU_SS 12 /*Stack exception*/

--- a/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
@@ -1,0 +1,129 @@
+/*
+    Copyright (C) 2021  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <cpuExceptions.h>
+#include <kout.h>
+#include <kpanic.h>
+
+#include <stdint.h>
+
+extern "C" void handleCpuException(uint64_t exceptionNumber,
+                                   uint64_t errorCode) {
+  switch (exceptionNumber) {
+  case CPU_DE: {
+    kout::print("Division exception\n");
+    break;
+  }
+  case CPU_DB: {
+    kout::print("Debug trap\n");
+    break;
+  }
+  case CPU_NMI: {
+    kout::print("Non-maskable interrupt\n");
+    break;
+  }
+  case CPU_BP: {
+    kout::print("Breakpoint\n");
+    break;
+  }
+  case CPU_OF: {
+    kout::print("Overflow exception\n");
+    break;
+  }
+  case CPU_BR: {
+    kout::print("Bound range exception\n");
+    break;
+  }
+  case CPU_UD: {
+    kout::print("Invalid opcode");
+    break;
+  }
+  case CPU_NM: {
+    kout::print("Device not available\n");
+    break;
+  }
+  case CPU_DF: {
+    kout::print("Double fault");
+    break;
+  }
+  case CPU_TS: {
+    kout::print("Invalid TSS\n");
+    break;
+  }
+  case CPU_NP: {
+    kout::print("Segment not present: ");
+    kout::print(errorCode);
+    kout::print("\n");
+    break;
+  }
+  case CPU_SS: {
+    kout::print("Stack exception\n");
+    break;
+  }
+  case CPU_GP: {
+    kout::print("General protection fault (");
+    kout::print(errorCode);
+    kout::print(")\n");
+    break;
+  }
+  case CPU_PF: {
+    kout::print("Page fault (");
+    kout::print(errorCode, 2);
+    kout::print(") on address ");
+    void *cr2Address;
+    __asm__ volatile("movq %%cr2, %0" : "=a"(cr2Address));
+    kout::print((unsigned long)cr2Address, 16);
+    kout::print("\n");
+    break;
+  }
+  case CPU_MF: {
+    kout::print("X87 error\n");
+    break;
+  }
+  case CPU_AC: {
+    kout::print("Alignment check exception\n");
+    break;
+  }
+  case CPU_MC: {
+    kout::print("Machine check exception\n");
+    break;
+  }
+  case CPU_XF: {
+    kout::print("SSE exception\n");
+    break;
+  }
+  case CPU_CP: {
+    kout::print("Control transfer exception\n");
+    break;
+  }
+  case CPU_HV: {
+    kout::print("Hyper visor exception\n");
+    break;
+  }
+  case CPU_VC: {
+    kout::print("VMM injection exception\n");
+    break;
+  }
+  case CPU_SX: {
+    kout::print("Security exception");
+    break;
+  }
+  default:
+    kout::print("Unimplemented exception number\n");
+    break;
+  }
+  kpanic("Non recoverable exception caught\n");
+}

--- a/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
@@ -20,8 +20,21 @@
 
 #include <stdint.h>
 
-extern "C" void handleCpuException(uint64_t exceptionNumber,
-                                   uint64_t errorCode) {
+struct InterruptStackFrame {
+  void *rip;
+  uint64_t cs;
+  uint64_t rflags;
+  void *rsp;
+  uint64_t ss;
+};
+static_assert(sizeof(InterruptStackFrame) == 40,
+              "InterruptStackFrame must be 40 bytes");
+
+extern "C" void handleCpuException(uint64_t exceptionNumber, uint64_t errorCode,
+                                   InterruptStackFrame *interruptStackFrame) {
+  kout::print("Exception at address 0x");
+  kout::print((unsigned long)interruptStackFrame->rip, 16);
+  kout::print(":\n");
   switch (exceptionNumber) {
   case CPU_DE: {
     kout::print("Division exception\n");

--- a/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
@@ -48,7 +48,7 @@ extern "C" void handleCpuException(uint64_t exceptionNumber,
     break;
   }
   case CPU_UD: {
-    kout::print("Invalid opcode");
+    kout::print("Invalid opcode\n");
     break;
   }
   case CPU_NM: {
@@ -56,7 +56,7 @@ extern "C" void handleCpuException(uint64_t exceptionNumber,
     break;
   }
   case CPU_DF: {
-    kout::print("Double fault");
+    kout::print("Double fault\n");
     break;
   }
   case CPU_TS: {
@@ -74,8 +74,8 @@ extern "C" void handleCpuException(uint64_t exceptionNumber,
     break;
   }
   case CPU_GP: {
-    kout::print("General protection fault (");
-    kout::print(errorCode);
+    kout::print("General protection fault (0x");
+    kout::print(errorCode, 16);
     kout::print(")\n");
     break;
   }
@@ -114,11 +114,11 @@ extern "C" void handleCpuException(uint64_t exceptionNumber,
     break;
   }
   case CPU_VC: {
-    kout::print("VMM injection exception\n");
+    kout::print("VMM communication exception\n");
     break;
   }
   case CPU_SX: {
-    kout::print("Security exception");
+    kout::print("Security exception\n");
     break;
   }
   default:

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -103,6 +103,7 @@ pushq %r10
 pushq %r11
 movq 8(%rbp), %rdi /*Exception number*/
 movq 16(%rbp), %rsi /*Error code*/
+leaq 24(%rbp), %rdx /*Interrupt stack frame*/
 callq handleCpuException
 popq %r11
 popq %r10

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -59,6 +59,7 @@ errorCodeExceptionHandler 11 /*#NP: Segment not present*/
 errorCodeExceptionHandler 12 /*#SS: Stack exception*/
 errorCodeExceptionHandler 14 /*#GP: General protection fault*/
 errorCodeExceptionHandler 14 /*#PF: Page fault*/
+reservedExceptions 1
 noErrorCodeExceptionHandler 16 /*#MF: X87 FPU exception*/
 errorCodeExceptionHandler 17 /*#AC: Alignment check exception*/
 noErrorCodeExceptionHandler 18 /*#MC: Machine check*/
@@ -72,7 +73,7 @@ errorCodeExceptionHandler 30 /*#SX: Security exception*/
 reservedExceptions 1
 
 currentInterruptNumber = 32
-.rept 256 - 32 /*Number of real (non-exception) interrupts*/
+.rept 255 - 32 /*Number of real (non-exception) interrupts*/
 .section .text.interruptHandlers, "ax"
 1:
 pushq $currentInterruptNumber
@@ -89,6 +90,30 @@ genericInterruptHandler:
 addq $8, %rsp
 iretq
 genericExceptionHandler:
-cli
-1: hlt
-jmp 1b
+pushq %rbp
+movq %rsp, %rbp
+pushq %rax
+pushq %rcx
+pushq %rdx
+pushq %rdi
+pushq %rsi
+pushq %r8
+pushq %r9
+pushq %r10
+pushq %r11
+movq 8(%rbp), %rdi /*Exception number*/
+movq 16(%rbp), %rsi /*Error code*/
+callq handleCpuException
+popq %r11
+popq %r10
+popq %r9
+popq %r8
+popq %rsi
+popq %rdi
+popq %rdx
+popq %rcx
+popq %rax
+movq %rbp, %rsp
+popq %rbp
+subq $16, %rsp /*Remove exception number and error code*/
+iretq

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.S
@@ -57,7 +57,7 @@ reservedExceptions 1
 errorCodeExceptionHandler 10 /*#TS: Invalid tss*/
 errorCodeExceptionHandler 11 /*#NP: Segment not present*/
 errorCodeExceptionHandler 12 /*#SS: Stack exception*/
-errorCodeExceptionHandler 14 /*#GP: General protection fault*/
+errorCodeExceptionHandler 13 /*#GP: General protection fault*/
 errorCodeExceptionHandler 14 /*#PF: Page fault*/
 reservedExceptions 1
 noErrorCodeExceptionHandler 16 /*#MF: X87 FPU exception*/

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -50,6 +50,7 @@ extern "C" [[noreturn]] void kstart() {
     // Continue
     interrupts::init();
     kout::print("Installed interrupt handlers\n");
+    __asm__ volatile("mov (%0), %1" : : "c"(0), "a"(0));
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -50,7 +50,9 @@ extern "C" [[noreturn]] void kstart() {
     // Continue
     interrupts::init();
     kout::print("Installed interrupt handlers\n");
-    __asm__ volatile("mov (%0), %1" : : "c"(0), "a"(0));
+    __asm__ volatile(
+        "movw $0x80, %ax;"
+        "movw %ax, %ds");
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -50,9 +50,6 @@ extern "C" [[noreturn]] void kstart() {
     // Continue
     interrupts::init();
     kout::print("Installed interrupt handlers\n");
-    __asm__ volatile(
-        "movw $0x80, %ax;"
-        "movw %ax, %ds");
     kpanic("It all worked");
   } else {
     // The tests failed! Abort


### PR DESCRIPTION
The exceptions used to just silently hang. This was not useful, as there would be no way of knowing what had happened or if there was even an exception.

This makes the exception mechanism print out some useful debug information and then call kpanic().