### PR TITLE
Allow unmapping of physical memory

### DIFF
--- a/kernel/include/kmalloc.h
+++ b/kernel/include/kmalloc.h
@@ -24,6 +24,7 @@ void *kmalloc(size_t size);
 void kfree(void *ptr);
 
 void *mapAddress(void *physicalAddress, size_t size);
+void unmapMemory(void *address, size_t size);
 } // namespace memory
 
 #endif

--- a/kernel/memory/kmalloc.cpp
+++ b/kernel/memory/kmalloc.cpp
@@ -56,6 +56,9 @@ void *mapAddress(void *physicalAddress, size_t size) {
   physicalAddress = (void *)PAGE_ALIGN_DOWN((size_t)physicalAddress);
   size = (size_t)((size_t)physicalEnd - (size_t)physicalAddress);
   void *ptr = virtualMemory.allocate(size);
+  if (ptr == nullptr) {
+    return nullptr;
+  }
   for (size_t i = 0; i < size; i += PAGE_SIZE) {
     paging::mapPage(ADD_TO_POINTER(ptr, i), ADD_TO_POINTER(physicalAddress, i),
                     paging::PageTableFlags::WRITABLE, false);

--- a/kernel/memory/kmalloc_test.cpp
+++ b/kernel/memory/kmalloc_test.cpp
@@ -47,7 +47,22 @@ bool kmallocTest(::test::Logger logger) {
   logger("kmallocTest: Succeeded\n");
   return true;
 }
+bool mapMemoryTest(::test::Logger logger) {
+  logger("mapMemoryTest:\n");
+  for (int i = 0; i < 4096; i++) {
+    void *ptr = mapAddress(nullptr, 1048576);
+    if (ptr == nullptr) {
+      logger("mapMemoryTest: Stress test failed\n");
+      return false;
+    } else {
+      unmapMemory(ptr, 1048576);
+    }
+  }
+  logger("mapMemoryTest: Succeeded\n");
+  return true;
+}
 ADD_TEST(kmallocTest);
+ADD_TEST(mapMemoryTest);
 } // namespace test
 } // namespace memory
 


### PR DESCRIPTION
There used to be no way of unmapping memory allocated by calling mapMemory().

This adds such a function (as well as a basic test for it).