### PR TITLE
Locate rsdp

### DIFF
--- a/kernel/arch/x86_64/include/mbi.h
+++ b/kernel/arch/x86_64/include/mbi.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include <acpi/rsdp.h>
+
 namespace multiboot {
 struct MbiTag {
   uint32_t type;
@@ -26,6 +28,8 @@ struct MbiTag {
 };
 #define MBI_TAG_MEMORY 6
 #define MBI_TAG_FRAME_BUFFER 8
+#define MBI_TAG_RSDP_OLD 14
+#define MBI_TAG_RSDP_NEW 15
 
 struct MemoryMapTag {
   uint32_t type;
@@ -41,9 +45,9 @@ struct MemoryMapTag {
 };
 static_assert(
     sizeof(MemoryMapTag) == 16,
-    "Invalid padding added to MemoryMapTag. Add __attribute__((__packed__))");
+    "Invalid padding added to MemoryMapTag. Add __attribute__((packed))");
 
-struct __attribute__((__packed__)) FrameBufferTag {
+struct __attribute__((packed)) FrameBufferTag {
   uint32_t type;
   uint32_t size;
   uint64_t address;
@@ -55,6 +59,21 @@ struct __attribute__((__packed__)) FrameBufferTag {
 };
 static_assert(sizeof(FrameBufferTag) == 29,
               "Invalid padding in FrameBufferTag");
+
+struct OldRsdpTag {
+  uint32_t type;
+  uint32_t size;
+  acpi::RsdpV1 rsdp;
+};
+static_assert(sizeof(OldRsdpTag) == sizeof(acpi::RsdpV1) + 8,
+              "Invalid padding added to OldRsdpTag");
+struct NewRsdpTag {
+  uint32_t type;
+  uint32_t size;
+  acpi::RsdpV2 rsdp;
+};
+static_assert(sizeof(NewRsdpTag) == sizeof(acpi::RsdpV2) + 8,
+              "Invalid padding added to NewRsdpTag");
 
 void parseMbi();
 class Mbi {

--- a/kernel/arch/x86_64/kernel/mbi.cpp
+++ b/kernel/arch/x86_64/kernel/mbi.cpp
@@ -97,5 +97,7 @@ static void parseFrameBufferTag(FrameBufferTag *tag) {
 static void parseOldRsdpTag(OldRsdpTag *tag) {
   memcpy(&acpi::rsdp, &tag->rsdp, sizeof(acpi::RsdpV1));
 }
-static void parseNewRsdpTag(NewRsdpTag *tag) { acpi::rsdp = tag->rsdp; }
+static void parseNewRsdpTag(NewRsdpTag *tag) {
+  memcpy(&acpi::rsdp, &tag->rsdp, sizeof(acpi::RsdpV2));
+}
 } // namespace multiboot

--- a/kernel/arch/x86_64/kernel/mbi.cpp
+++ b/kernel/arch/x86_64/kernel/mbi.cpp
@@ -18,6 +18,9 @@
 #include <mbi.h>
 #include <pageConstants.h>
 #include <physicalMemory.h>
+#include <string.h>
+
+#include <acpi/rsdp.h>
 
 extern "C" {
 extern multiboot::Mbi *mbiPointer;
@@ -28,6 +31,10 @@ extern void *kernelPhysicalEnd[0];
 
 namespace memory {
 BlockMap physicalMemory;
+}
+
+namespace acpi {
+RsdpV2 rsdp;
 }
 
 namespace multiboot {
@@ -41,6 +48,8 @@ void parseMbi() {
 }
 static void parseMemoryMapTag(MemoryMapTag *memoryMap);
 static void parseFrameBufferTag(FrameBufferTag *tag);
+static void parseOldRsdpTag(OldRsdpTag *tag);
+static void parseNewRsdpTag(NewRsdpTag *tag);
 static void parseMbiTag(uint32_t type, MbiTag *tag) {
   switch (type) {
   case MBI_TAG_MEMORY: {
@@ -49,6 +58,14 @@ static void parseMbiTag(uint32_t type, MbiTag *tag) {
   }
   case MBI_TAG_FRAME_BUFFER: {
     parseFrameBufferTag((FrameBufferTag *)tag);
+    break;
+  }
+  case MBI_TAG_RSDP_OLD: {
+    parseOldRsdpTag((OldRsdpTag *)tag);
+    break;
+  }
+  case MBI_TAG_RSDP_NEW: {
+    parseNewRsdpTag((NewRsdpTag *)tag);
     break;
   }
   default:
@@ -77,4 +94,8 @@ static void parseFrameBufferTag(FrameBufferTag *tag) {
   display::frameBuffer.depth = tag->depth;
   display::frameBuffer.pitch = tag->pitch;
 }
+static void parseOldRsdpTag(OldRsdpTag *tag) {
+  memcpy(&acpi::rsdp, &tag->rsdp, sizeof(acpi::RsdpV1));
+}
+static void parseNewRsdpTag(NewRsdpTag *tag) { acpi::rsdp = tag->rsdp; }
 } // namespace multiboot

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -14,6 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
+#include <string.h>
 
 #include <mbi.h>
 #include <pageTableInit.h>
@@ -26,6 +27,8 @@
 #include <interrupts.h>
 
 #include <kpanic.h>
+
+#include <acpi/rsdp.h>
 
 typedef void (*ConstructorOrDestructor)();
 
@@ -49,7 +52,16 @@ extern "C" [[noreturn]] void kstart() {
   if (test::runTests(kout::print)) {
     // Continue
     interrupts::init();
-    kout::print("Installed interrupt handlers\n");
+    kout::print("Installed interrupt handlers\n\n");
+    if (!memeq(acpi::rsdp.signature, "RSD PTR ", 8)) {
+      kpanic("No acpi found");
+    }
+    if (!acpi::rsdp.doChecksum()) {
+      kpanic("Checksum of rsdp failed");
+    }
+    kout::print("Found rsdp (revision: ");
+    kout::print(acpi::rsdp.revision);
+    kout::print(")\n");
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/include/acpi/rsdp.h
+++ b/kernel/include/acpi/rsdp.h
@@ -39,6 +39,16 @@ struct __attribute__((packed)) RsdpV2 {
   uint64_t xsdtAddress;
   uint8_t extendedChecksum;
   uint8_t reserved[3];
+
+  bool doChecksum() {
+    unsigned char *rsdpBytes = (unsigned char *)this;
+    unsigned char sum = 0;
+    for (unsigned i = 0; i < (revision >= 2 ? sizeof(RsdpV2) : sizeof(RsdpV1));
+         i++) {
+      sum += rsdpBytes[i];
+    }
+    return sum == 0;
+  }
 };
 static_assert(sizeof(RsdpV2) == 36, "RsdpV2 must be 36 bytes");
 

--- a/kernel/include/acpi/rsdp.h
+++ b/kernel/include/acpi/rsdp.h
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _ACPI_RSDP_H
+#define _ACPI_RSDP_H
+
+#include <stdint.h>
+
+namespace acpi {
+struct RsdpV1 {
+  char signature[8]; // "RSD PTR "
+  uint8_t checksum;
+  char oemId[6];
+  uint8_t revision;
+  uint32_t rsdtAddress;
+};
+static_assert(sizeof(RsdpV1) == 20, "RsdpV1 must be 20 bytes");
+struct __attribute__((packed)) RsdpV2 {
+  char signature[8]; // "RSD PTR "
+  uint8_t checksum;
+  char oemId[6];
+  uint8_t revision;
+  uint32_t rsdtAddress;
+
+  uint32_t length;
+  uint64_t xsdtAddress;
+  uint8_t extendedChecksum;
+  uint8_t reserved[3];
+};
+static_assert(sizeof(RsdpV2) == 36, "RsdpV2 must be 36 bytes");
+
+// V1 structure can fit in v2, so just use v2 structure
+extern RsdpV2 rsdp;
+} // namespace acpi
+
+#endif


### PR DESCRIPTION
The multiboot2 loader (probably grub) passes the RSDP tag to the kernel in the MBI.

This makes the kernel read the RSDP and validate it.