### PR TITLE
Parse acpi tables

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -27,6 +27,7 @@ include test/Make.steps
 include memory/Make.steps
 include display/Make.steps
 include error/Make.steps
+include acpi/Make.steps
 
 # Enable runtime tests if requested
 ifeq ($(TEST),ON)

--- a/kernel/acpi/Make.steps
+++ b/kernel/acpi/Make.steps
@@ -1,1 +1,1 @@
-STEPS+=acpi/tables.o
+STEPS+=acpi/tables.o acpi/rsdt.o

--- a/kernel/acpi/Make.steps
+++ b/kernel/acpi/Make.steps
@@ -1,0 +1,1 @@
+STEPS+=acpi/tables.o

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -18,27 +18,33 @@
 
 #include <kmalloc.h>
 
+// REMOVETHIS
+#include <kout.h>
+
 namespace acpi {
 RsdtTableManager::RsdtTableManager(TableHeader *header)
     : TableManager(TableType::RSDT) {
   size_t entrySize = header->signature[0] == 'X' ? 8 : 4;
   numChildren = (header->length - sizeof(TableHeader)) / entrySize;
   children = new TableManager *[numChildren];
-  uint8_t *entryStart = (uint8_t *)header + sizeof(TableHeader);
+  uint8_t *entry = (uint8_t *)header + sizeof(TableHeader);
   for (unsigned i = 0; i < numChildren; i++) {
     switch (entrySize) {
     case 4: {
-      children[i] = loadTable((void *)(size_t)((uint32_t *)entryStart)[i]);
+      uint32_t entryValue = *(uint32_t *)entry;
+      children[i] = loadTable((void *)(size_t)entryValue);
       break;
     }
     case 8: {
-      children[i] = loadTable((void *)(size_t)((uint64_t *)entryStart)[i]);
+      uint64_t entryValue = *(uint64_t *)entry;
+      children[i] = loadTable((void *)(size_t)entryValue);
       break;
     }
     default:
       children[i] = nullptr;
       break;
     }
+    entry += entrySize;
   }
   memory::unmapMemory(header, header->length);
 }

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -14,5 +14,17 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
-   #include <acpi/tables.h>
-   #include <acpi/rsdt.h>
+#include <acpi/rsdt.h>
+
+#include <kmalloc.h>
+
+namespace acpi {
+RsdtTableManager::RsdtTableManager(TableHeader *header)
+    : TableManager(TableType::RSDT) {
+  size_t entrySize = header->signature[0] == 'X' ? 8 : 4;
+  numChildren = (header->length - sizeof(TableHeader)) / entrySize;
+  children = new TableManager *[numChildren];
+  // TODO: Load the subtables
+  memory::unmapMemory(header, header->length);
+}
+} // namespace acpi

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -24,7 +24,6 @@ RsdtTableManager::RsdtTableManager(TableHeader *header)
   size_t entrySize = header->signature[0] == 'X' ? 8 : 4;
   numChildren = (header->length - sizeof(TableHeader)) / entrySize;
   children = new TableManager *[numChildren];
-  // TODO: Load the subtables
   uint8_t *entryStart = (uint8_t *)header + sizeof(TableHeader);
   for (unsigned i = 0; i < numChildren; i++) {
     switch (entrySize) {

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -25,6 +25,29 @@ RsdtTableManager::RsdtTableManager(TableHeader *header)
   numChildren = (header->length - sizeof(TableHeader)) / entrySize;
   children = new TableManager *[numChildren];
   // TODO: Load the subtables
+  uint8_t *entryStart = (uint8_t *)header + sizeof(TableHeader);
+  for (unsigned i = 0; i < numChildren; i++) {
+    switch (entrySize) {
+    case 4: {
+      children[i] = loadTable((void *)(size_t)((uint32_t *)entryStart)[i]);
+      break;
+    }
+    case 8: {
+      children[i] = loadTable((void *)(size_t)((uint64_t *)entryStart)[i]);
+      break;
+    }
+    default:
+      children[i] = nullptr;
+      break;
+    }
+  }
   memory::unmapMemory(header, header->length);
+}
+RsdtTableManager::~RsdtTableManager() {
+  for (unsigned i = 0; i < numChildren; i++) {
+    if (children[i] != nullptr) {
+      delete children[i];
+    }
+  }
 }
 } // namespace acpi

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -18,9 +18,6 @@
 
 #include <kmalloc.h>
 
-// REMOVETHIS
-#include <kout.h>
-
 namespace acpi {
 RsdtTableManager::RsdtTableManager(TableHeader *header)
     : TableManager(TableType::RSDT) {
@@ -54,5 +51,6 @@ RsdtTableManager::~RsdtTableManager() {
       delete children[i];
     }
   }
+  delete[] children;
 }
 } // namespace acpi

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -48,20 +48,15 @@ static bool doChecksum(TableHeader *header) {
 }
 
 TableManager *loadTable(void *physicalAddress) {
-  kout::print("Loading table at 0x");
-  kout::print((unsigned long)physicalAddress, 16);
-  kout::print(": ");
+  kout::print("Loading ACPI table: ");
   TableHeader *header =
       (TableHeader *)memory::mapAddress(physicalAddress, sizeof(TableHeader));
   char nullTerminatedSignature[5];
   memcpy(nullTerminatedSignature, header->signature, 4);
   nullTerminatedSignature[4] = 0;
   kout::print(nullTerminatedSignature);
-  kout::print(" with ");
-  size_t tableSize = header->length;
-  kout::print("Size: ");
-  kout::print(tableSize);
   kout::print("\n");
+  size_t tableSize = header->length;
   if (tableSize < sizeof(TableHeader)) {
     kout::print("Invalid table: Size too small\n");
     return nullptr;
@@ -75,9 +70,6 @@ TableManager *loadTable(void *physicalAddress) {
   for (unsigned i = 0; i < numTableHandlers; i++) {
     TableHandler handler = tableHandlers[i];
     if (memeq(header->signature, handler.signature, 4)) {
-      kout::print("Matching against handler accepting signature '");
-      kout::print(handler.signature);
-      kout::print("'\n");
       return handler.creator(header);
     }
   }

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -14,6 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
+#include <acpi/rsdp.h>
 #include <acpi/tables.h>
 
 #include <acpi/rsdt.h>
@@ -72,11 +73,15 @@ TableManager *loadTable(void *physicalAddress) {
     return nullptr;
   }
   for (unsigned i = 0; i < numTableHandlers; i++) {
-    TableHandler &handler = tableHandlers[i];
+    TableHandler handler = tableHandlers[i];
     if (memeq(header->signature, handler.signature, 4)) {
+      kout::print("Matching against handler accepting signature '");
+      kout::print(handler.signature);
+      kout::print("'\n");
       return handler.creator(header);
     }
   }
+  // No suitable handler
   memory::unmapMemory(header, tableSize);
   return nullptr;
 }

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -1,0 +1,18 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+   #include <acpi/tables.h>
+   

--- a/kernel/arch/x86_64/kernel/memory/copying.cpp
+++ b/kernel/arch/x86_64/kernel/memory/copying.cpp
@@ -42,11 +42,12 @@ extern "C" void *memcpy(void *dst, const void *src, size_t n) {
   return dst;
 }
 extern "C" int memcmp(const void *a, const void *b, size_t n) {
-  size_t finalN = n;
-  __asm__ volatile("repe cmpsb" : "+c"(finalN) : "D"(a), "S"(b) : "memory");
-  if (finalN == 0) {
-    return 0;
-  } else {
-    return ((unsigned char *)a)[n - finalN] - ((unsigned char *)b)[n - finalN];
+  unsigned char *aPointer = (unsigned char *)a;
+  unsigned char *bPointer = (unsigned char *)b;
+  for (size_t i = 0; i < n; i++) {
+    if (aPointer[i] != bPointer[i]) {
+      return aPointer[i] - bPointer[i];
+    }
   }
+  return 0;
 }

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -29,6 +29,7 @@
 #include <kpanic.h>
 
 #include <acpi/rsdp.h>
+#include <acpi/tables.h>
 
 typedef void (*ConstructorOrDestructor)();
 
@@ -62,6 +63,14 @@ extern "C" [[noreturn]] void kstart() {
     kout::print("Found rsdp (revision: ");
     kout::print(acpi::rsdp.revision);
     kout::print(")\n");
+    void *rsdtAddress = (acpi::rsdp.revision >= 2)
+                            ? (void *)(size_t)acpi::rsdp.xsdtAddress
+                            : (void *)(size_t)acpi::rsdp.rsdtAddress;
+    acpi::TableManager *rsdt = acpi::loadTable(rsdtAddress);
+    if (rsdt == nullptr) {
+      kpanic("Error loading rsdt");
+    }
+      kout::print("Found rsdt\n");
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -70,7 +70,7 @@ extern "C" [[noreturn]] void kstart() {
     if (rsdt == nullptr) {
       kpanic("Error loading rsdt");
     }
-      kout::print("Found rsdt\n");
+    kout::print("Found rsdt\n");
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/display/font/psfRenderer.cpp
+++ b/kernel/display/font/psfRenderer.cpp
@@ -40,7 +40,6 @@ extern PsfFile _binary_display_font_font_psf_start;
 namespace font {
 void render(char c, unsigned x, unsigned y, display::Pixel foreground,
             display::Pixel background) {
-
   uint8_t *glyph = fontFile.data + (c * fontFile.glyphSize);
   for (unsigned glyphY = 0; glyphY < fontFile.height; glyphY++) {
     for (unsigned glyphX = 0; glyphX < fontFile.width; glyphX++) {

--- a/kernel/display/font/psfRenderer.cpp
+++ b/kernel/display/font/psfRenderer.cpp
@@ -40,6 +40,7 @@ extern PsfFile _binary_display_font_font_psf_start;
 namespace font {
 void render(char c, unsigned x, unsigned y, display::Pixel foreground,
             display::Pixel background) {
+
   uint8_t *glyph = fontFile.data + (c * fontFile.glyphSize);
   for (unsigned glyphY = 0; glyphY < fontFile.height; glyphY++) {
     for (unsigned glyphX = 0; glyphX < fontFile.width; glyphX++) {

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -14,5 +14,22 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
-   #include <acpi/tables.h>
-   #include <acpi/rsdt.h>
+#ifndef _ACPI_RSDT_H
+#define _ACPI_RSDT_H
+
+#include <acpi/tables.h>
+
+#include <stddef.h>
+
+namespace acpi {
+class RsdtTableManager : public TableManager {
+public:
+  RsdtTableManager(TableHeader *header);
+
+private:
+  TableManager **children;
+  size_t numChildren;
+};
+} // namespace acpi
+
+#endif

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -27,8 +27,7 @@ public:
   RsdtTableManager(TableHeader *header);
   virtual ~RsdtTableManager();
 
- private:
-  TableManager **children;
+      private : TableManager **children;
   size_t numChildren;
 };
 } // namespace acpi

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -27,7 +27,8 @@ public:
   RsdtTableManager(TableHeader *header);
   virtual ~RsdtTableManager();
 
-      private : TableManager **children;
+private:
+  TableManager **children;
   size_t numChildren;
 };
 } // namespace acpi

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -25,8 +25,9 @@ namespace acpi {
 class RsdtTableManager : public TableManager {
 public:
   RsdtTableManager(TableHeader *header);
+  virtual ~RsdtTableManager();
 
-private:
+ private:
   TableManager **children;
   size_t numChildren;
 };

--- a/kernel/include/acpi/tables.h
+++ b/kernel/include/acpi/tables.h
@@ -38,6 +38,8 @@ class TableManager {
 public:
   const TableType type;
 
+  virtual ~TableManager() {}
+
 protected:
   TableManager(TableType type) : type(type) {}
 };

--- a/kernel/include/acpi/tables.h
+++ b/kernel/include/acpi/tables.h
@@ -1,0 +1,46 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _ACPI_TABLES_H
+#define _ACPI_TABLES_H
+
+#include <stdint.h>
+
+namespace acpi {
+struct TableHeader {
+  char signature[4];
+  uint32_t length;
+  uint8_t revision;
+  uint8_t checksum;
+  char oemId[6];
+  char oemTableId[8];
+  uint32_t oemRevision;
+  char creatorId[4];
+  uint32_t creatorRevision;
+};
+static_assert(sizeof(TableHeader) == 36, "TableHeader incorrect size");
+
+enum class TableType {};
+class TableManager {
+public:
+  const TableType type;
+
+protected:
+  TableManager(TableType type) : type(type) {}
+};
+} // namespace acpi
+
+#endif

--- a/kernel/include/acpi/tables.h
+++ b/kernel/include/acpi/tables.h
@@ -44,7 +44,7 @@ protected:
   TableManager(TableType type) : type(type) {}
 };
 
-TableManager* loadTable(void* physicalAddress);
-}  // namespace acpi
+TableManager *loadTable(void *physicalAddress);
+} // namespace acpi
 
 #endif

--- a/kernel/include/acpi/tables.h
+++ b/kernel/include/acpi/tables.h
@@ -33,7 +33,7 @@ struct TableHeader {
 };
 static_assert(sizeof(TableHeader) == 36, "TableHeader incorrect size");
 
-enum class TableType {};
+enum class TableType { RSDT };
 class TableManager {
 public:
   const TableType type;

--- a/kernel/include/acpi/tables.h
+++ b/kernel/include/acpi/tables.h
@@ -43,6 +43,8 @@ public:
 protected:
   TableManager(TableType type) : type(type) {}
 };
-} // namespace acpi
+
+TableManager* loadTable(void* physicalAddress);
+}  // namespace acpi
 
 #endif

--- a/kernel/memory/copying_test.cpp
+++ b/kernel/memory/copying_test.cpp
@@ -22,12 +22,22 @@ bool memcmpTest(::test::Logger logger) {
   logger("memcmpTest:\n");
   char buffer1[] = "Hello, World!";
   char buffer2[] = "Hello, There!";
+  char buffer3[] = "Test";
+  char buffer4[] = "Best";
   if (memcmp(buffer1, buffer1, sizeof(buffer1)) != 0) {
     logger("memcmpTest: equality test failed\n");
     return false;
   }
   if (memcmp(buffer2, buffer2, sizeof(buffer2)) != 0) {
     logger("memcmpTest: equality test failed\n");
+    return false;
+  }
+  if (memcmp(buffer3, buffer3, strlen(buffer3)) != 0) {
+    logger("memcmpTest: Equality test failed on small array\n");
+    return false;
+  }
+  if (memcmp(buffer4, buffer4, strlen(buffer4)) != 0) {
+    logger("memcmpTest: Equality test failed on small array\n");
     return false;
   }
   logger("memcmpTest: Passed equality test\n");
@@ -37,6 +47,14 @@ bool memcmpTest(::test::Logger logger) {
   }
   if (memcmp(buffer2, buffer1, sizeof(buffer2)) == 0) {
     logger("memcmpTest: Failed inequality test\n");
+    return false;
+  }
+  if (memcmp(buffer3, buffer4, strlen(buffer3)) == 0) {
+    logger("memcmpTest: Inequality test failed on small array\n");
+    return false;
+  }
+  if (memcmp(buffer4, buffer3, strlen(buffer4) == 0)) {
+    logger("memcmpTest: Inequality test failed on small array\n");
     return false;
   }
   logger("memcmpTest: Passed inequality test\n");

--- a/kernel/memory/kmalloc.cpp
+++ b/kernel/memory/kmalloc.cpp
@@ -76,3 +76,12 @@ void unmapMemory(void *address, size_t size) {
   }
 }
 } // namespace memory
+
+void *operator new(size_t size) { return memory::kmalloc(size); }
+void *operator new[](size_t size) { return memory::kmalloc(size); }
+
+void operator delete(void *ptr) { memory::kfree(ptr); }
+void operator delete[](void *ptr) { memory::kfree(ptr); }
+
+void operator delete(void *ptr, size_t) { memory::kfree(ptr); }
+void operator delete[](void *ptr, size_t) { memory::kfree(ptr); }


### PR DESCRIPTION
The kernel now parses the rsdt/xsdt to find all of the sub tables. Currently, none of these are supported, but they probably will be in future.