### PR TITLE
added an option to control weather memory from mapAddress is cacheable

### DIFF
--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -50,7 +50,7 @@ static bool doChecksum(TableHeader *header) {
 TableManager *loadTable(void *physicalAddress) {
   kout::print("Loading ACPI table: ");
   TableHeader *header =
-      (TableHeader *)memory::mapAddress(physicalAddress, sizeof(TableHeader));
+      (TableHeader *)memory::mapAddress(physicalAddress, sizeof(TableHeader), true);
   char nullTerminatedSignature[5];
   memcpy(nullTerminatedSignature, header->signature, 4);
   nullTerminatedSignature[4] = 0;
@@ -62,9 +62,10 @@ TableManager *loadTable(void *physicalAddress) {
     return nullptr;
   }
   memory::unmapMemory(header, sizeof(TableHeader));
-  header = (TableHeader *)memory::mapAddress(physicalAddress, tableSize);
+  header = (TableHeader *)memory::mapAddress(physicalAddress, tableSize, true);
   if (!doChecksum(header)) {
     kout::print("Table did not pass checksum\n");
+    memory::unmapMemory(header, header->length);
     return nullptr;
   }
   for (unsigned i = 0; i < numTableHandlers; i++) {

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -49,8 +49,8 @@ static bool doChecksum(TableHeader *header) {
 
 TableManager *loadTable(void *physicalAddress) {
   kout::print("Loading ACPI table: ");
-  TableHeader *header =
-      (TableHeader *)memory::mapAddress(physicalAddress, sizeof(TableHeader), true);
+  TableHeader *header = (TableHeader *)memory::mapAddress(
+      physicalAddress, sizeof(TableHeader), true);
   char nullTerminatedSignature[5];
   memcpy(nullTerminatedSignature, header->signature, 4);
   nullTerminatedSignature[4] = 0;

--- a/kernel/arch/x86_64/include/pageTables.h
+++ b/kernel/arch/x86_64/include/pageTables.h
@@ -25,6 +25,7 @@ enum class PageTableFlags : uint64_t {
   PRESENT = 1 << 0,
   WRITABLE = 1 << 1,
   USER = 1 << 2,
+  UNCACHEABLE = 1 << 4,
   // Available bits
   ALLOCATED = 1 << 11
 };

--- a/kernel/arch/x86_64/include/paging.h
+++ b/kernel/arch/x86_64/include/paging.h
@@ -21,7 +21,7 @@
 
 namespace paging {
 void mapPage(void *virtualAddress, void *physicalAddress, PageTableFlags flags,
-             bool allocated);
+             bool allocated, bool cacheable);
 void unmapPage(void *virtualAddress);
 } // namespace paging
 

--- a/kernel/arch/x86_64/kernel/paging/paging.cpp
+++ b/kernel/arch/x86_64/kernel/paging/paging.cpp
@@ -85,10 +85,13 @@ static PageTableEntry *getPageTableEntry(void *virtualAddress,
   return &PML1ENTRY(pml4Index, pml3Index, pml2Index, pml1Index);
 }
 void mapPage(void *virtualAddress, void *physicalAddress, PageTableFlags flags,
-             bool allocated) {
+             bool allocated, bool cacheable) {
   flags |= PageTableFlags::PRESENT;
   if (allocated) {
     flags |= PageTableFlags::ALLOCATED;
+  }
+  if (!cacheable) {
+    flags |= PageTableFlags::UNCACHEABLE;
   }
   PageTableEntry pageTableEntry =
       (PageTableEntry)((uint64_t)flags | ((uint64_t)physicalAddress & ~4095ul));

--- a/kernel/display/frameBuffer.cpp
+++ b/kernel/display/frameBuffer.cpp
@@ -23,7 +23,7 @@ namespace display {
 FrameBuffer frameBuffer;
 void initFrameBuffer() {
   frameBuffer.pointer = (uint8_t *)memory::mapAddress(
-      frameBuffer.pointer, frameBuffer.pitch * frameBuffer.height);
+      frameBuffer.pointer, frameBuffer.pitch * frameBuffer.height, false);
   memset(frameBuffer.pointer, 0, frameBuffer.pitch * frameBuffer.height);
 }
 void writePixel(unsigned x, unsigned y, Pixel pixel) {

--- a/kernel/include/kmalloc.h
+++ b/kernel/include/kmalloc.h
@@ -23,7 +23,7 @@ namespace memory {
 void *kmalloc(size_t size);
 void kfree(void *ptr);
 
-void *mapAddress(void *physicalAddress, size_t size);
+void *mapAddress(void *physicalAddress, size_t size, bool cacheable);
 void unmapMemory(void *address, size_t size);
 } // namespace memory
 

--- a/kernel/memory/kmalloc.cpp
+++ b/kernel/memory/kmalloc.cpp
@@ -38,7 +38,7 @@ void *kmalloc(size_t size) {
   for (size_t i = 0; i < size; i += PAGE_SIZE) {
     paging::mapPage(ADD_TO_POINTER(ptr, i),
                     (void *)(memory::allocateFrame() * PAGE_SIZE),
-                    paging::PageTableFlags::WRITABLE, true);
+                    paging::PageTableFlags::WRITABLE, true, true);
   }
   KmallocHeader *headerPtr = (KmallocHeader *)ptr;
   *headerPtr = {.size = size};
@@ -51,7 +51,7 @@ void kfree(void *ptr) {
   ptr = (void *)headerPtr;
   unmapMemory(ptr, size);
 }
-void *mapAddress(void *physicalAddress, size_t size) {
+void *mapAddress(void *physicalAddress, size_t size, bool cacheable) {
   size_t pageOffset = (size_t)physicalAddress % PAGE_SIZE;
   void *physicalEnd = (void *)PAGE_ALIGN_UP((size_t)physicalAddress + size);
   physicalAddress = (void *)PAGE_ALIGN_DOWN((size_t)physicalAddress);
@@ -62,7 +62,7 @@ void *mapAddress(void *physicalAddress, size_t size) {
   }
   for (size_t i = 0; i < size; i += PAGE_SIZE) {
     paging::mapPage(ADD_TO_POINTER(ptr, i), ADD_TO_POINTER(physicalAddress, i),
-                    paging::PageTableFlags::WRITABLE, false);
+                    paging::PageTableFlags::WRITABLE, false, cacheable);
   }
   return ADD_TO_POINTER(ptr, pageOffset);
 }

--- a/kernel/memory/kmalloc_test.cpp
+++ b/kernel/memory/kmalloc_test.cpp
@@ -50,7 +50,7 @@ bool kmallocTest(::test::Logger logger) {
 bool mapMemoryTest(::test::Logger logger) {
   logger("mapMemoryTest:\n");
   for (int i = 0; i < 4096; i++) {
-    void *ptr = mapAddress(nullptr, 1048576);
+    void *ptr = mapAddress(nullptr, 1048576, true);
     if (ptr == nullptr) {
       logger("mapMemoryTest: Stress test failed\n");
       return false;


### PR DESCRIPTION
There used to be no way to stop the memory from memory::mapAddress() from being cached. This was an issue, as memory mapped hardware would not work properly with caching enabled.

This adds a new parameter to the mapAddress field to control weather the memory will be cacheable or not.