### PR TITLE
Create kprintf function

### DIFF
--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -51,10 +51,7 @@ TableManager *loadTable(void *physicalAddress) {
   kout::print("Loading ACPI table: ");
   TableHeader *header = (TableHeader *)memory::mapAddress(
       physicalAddress, sizeof(TableHeader), true);
-  char nullTerminatedSignature[5];
-  memcpy(nullTerminatedSignature, header->signature, 4);
-  nullTerminatedSignature[4] = 0;
-  kout::print(nullTerminatedSignature);
+  kout::print(header->signature, 4);
   kout::print("\n");
   size_t tableSize = header->length;
   if (tableSize < sizeof(TableHeader)) {

--- a/kernel/arch/x86_64/bootstrap/multiboot.S
+++ b/kernel/arch/x86_64/bootstrap/multiboot.S
@@ -19,7 +19,7 @@
 #define MULTIBOOT2_MAGIC 0xE85250D6
 #define MULTIBOOT2_ARCHITECTURE 0
 
-.section .multiboot
+.section .multiboot, "a"
 
 .align 8
 multiboot_header:

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -71,6 +71,10 @@ extern "C" [[noreturn]] void kstart() {
       kpanic("Error loading rsdt");
     }
     kout::print("Found rsdt\n");
+    kout::printf(
+        "Testing %s with a hexadecimal 0x%x and octal 0%o as well as a char "
+        "%c and long %l\n",
+        "printf", 32l, 32l, ';', 32);
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -71,10 +71,6 @@ extern "C" [[noreturn]] void kstart() {
       kpanic("Error loading rsdt");
     }
     kout::print("Found rsdt\n");
-    kout::printf(
-        "Testing %s with a hexadecimal 0x%x and octal 0%o as well as a char "
-        "%c and long %l\n",
-        "printf", 32l, 32l, ';', 32);
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/display/Make.steps
+++ b/kernel/display/Make.steps
@@ -1,7 +1,7 @@
 STEPS+=display/frameBuffer.o
 STEPS+=display/font/font.o display/font/psfRenderer.o
 STEPS+=display/stringWriter.o
-STEPS+=display/console/console.o
+STEPS+=display/console/console.o display/console/printf.o
 
 %.o: %.psf
 	echo "objcopy $@"

--- a/kernel/display/console/console.cpp
+++ b/kernel/display/console/console.cpp
@@ -64,7 +64,7 @@ void scrollDown() {
   lastLine[0] = 0;
 }
 
-void print(const char *str) {
+void print(const char *str, int len) {
   if (columns == 0) {
     columns = display::getWidth() / font::getWidth();
     lines = display::getHeight() / font::getHeight();
@@ -75,7 +75,7 @@ void print(const char *str) {
   }
   unsigned x = column * font::getWidth();
   unsigned y = line * font::getHeight();
-  while (*str != 0) {
+  for (int i = 0; i < len; i ++) {
     if (column >= columns || *str == '\n') {
       column = x = 0;
       if (line < lines - 1) {

--- a/kernel/display/console/console.cpp
+++ b/kernel/display/console/console.cpp
@@ -75,7 +75,7 @@ void print(const char *str, int len) {
   }
   unsigned x = column * font::getWidth();
   unsigned y = line * font::getHeight();
-  for (int i = 0; i < len; i ++) {
+  for (int i = 0; i < len; i++) {
     if (column >= columns || *str == '\n') {
       column = x = 0;
       if (line < lines - 1) {

--- a/kernel/display/console/printf.cpp
+++ b/kernel/display/console/printf.cpp
@@ -74,7 +74,8 @@ void printf(const char *format, ...) {
               default:
                 print("<unknown type specifier>");
             }
-      }else {
+            format++;
+      } else {
         const char *nextSpecifier = strchr(format, '%');
         int len;
         if (nextSpecifier != 0) {
@@ -83,8 +84,8 @@ void printf(const char *format, ...) {
           len = strlen(format);
         }
         print(format, len);
+        format += len;
       }
-      format++;
   }
   va_end(args);
 }

--- a/kernel/display/console/printf.cpp
+++ b/kernel/display/console/printf.cpp
@@ -1,0 +1,91 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#include <kout.h>
+
+#include <stdarg.h>
+
+#include <string.h>
+
+namespace kout {
+void printf(const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  while (*format != 0) {
+      if (*format == '%') {
+        format++;
+        switch (*format) {
+            case 'n': {
+              break;
+            }
+            case '%': {
+              print("%", 1);
+              break;
+            }
+            case 'c': {
+              char c = (char)va_arg(args, int);
+              print(&c, 1);
+              break;
+            }
+            case 'd': {
+              int n = va_arg(args, int);
+              print(n);
+              break;
+            }
+            case 'l': {
+              long l = va_arg(args, long);
+              print(l);
+              break;
+            }
+            case 'o': {
+              long l = va_arg(args, long);
+              print(l, 8);
+              break;
+            }
+            case 'p': {
+              void *ptr = va_arg(args, void *);
+              print("0x");
+              print((unsigned long)ptr, 16);
+              break;
+            }
+              case 's': {
+                const char *str = va_arg(args, const char *);
+                print(str);
+                break;
+              }
+              case 'x': {
+                long l = va_arg(args, long);
+                print(l, 16);
+                break;
+              }
+              default:
+                print("<unknown type specifier>");
+            }
+      }else {
+        const char *nextSpecifier = strchr(format, '%');
+        int len;
+        if (nextSpecifier != 0) {
+          len = nextSpecifier - format;
+        }else {
+          len = strlen(format);
+        }
+        print(format, len);
+      }
+      format++;
+  }
+  va_end(args);
+}
+} // namespace kout

--- a/kernel/display/console/printf.cpp
+++ b/kernel/display/console/printf.cpp
@@ -25,67 +25,67 @@ void printf(const char *format, ...) {
   va_list args;
   va_start(args, format);
   while (*format != 0) {
-      if (*format == '%') {
-        format++;
-        switch (*format) {
-            case 'n': {
-              break;
-            }
-            case '%': {
-              print("%", 1);
-              break;
-            }
-            case 'c': {
-              char c = (char)va_arg(args, int);
-              print(&c, 1);
-              break;
-            }
-            case 'd': {
-              int n = va_arg(args, int);
-              print(n);
-              break;
-            }
-            case 'l': {
-              long l = va_arg(args, long);
-              print(l);
-              break;
-            }
-            case 'o': {
-              long l = va_arg(args, long);
-              print(l, 8);
-              break;
-            }
-            case 'p': {
-              void *ptr = va_arg(args, void *);
-              print("0x");
-              print((unsigned long)ptr, 16);
-              break;
-            }
-              case 's': {
-                const char *str = va_arg(args, const char *);
-                print(str);
-                break;
-              }
-              case 'x': {
-                long l = va_arg(args, long);
-                print(l, 16);
-                break;
-              }
-              default:
-                print("<unknown type specifier>");
-            }
-            format++;
-      } else {
-        const char *nextSpecifier = strchr(format, '%');
-        int len;
-        if (nextSpecifier != 0) {
-          len = nextSpecifier - format;
-        }else {
-          len = strlen(format);
-        }
-        print(format, len);
-        format += len;
+    if (*format == '%') {
+      format++;
+      switch (*format) {
+      case 'n': {
+        break;
       }
+      case '%': {
+        print("%", 1);
+        break;
+      }
+      case 'c': {
+        char c = (char)va_arg(args, int);
+        print(&c, 1);
+        break;
+      }
+      case 'd': {
+        int n = va_arg(args, int);
+        print(n);
+        break;
+      }
+      case 'l': {
+        long l = va_arg(args, long);
+        print(l);
+        break;
+      }
+      case 'o': {
+        long l = va_arg(args, long);
+        print(l, 8);
+        break;
+      }
+      case 'p': {
+        void *ptr = va_arg(args, void *);
+        print("0x");
+        print((unsigned long)ptr, 16);
+        break;
+      }
+      case 's': {
+        const char *str = va_arg(args, const char *);
+        print(str);
+        break;
+      }
+      case 'x': {
+        long l = va_arg(args, long);
+        print(l, 16);
+        break;
+      }
+      default:
+        print("<unknown type specifier>");
+      }
+      format++;
+    } else {
+      const char *nextSpecifier = strchr(format, '%');
+      int len;
+      if (nextSpecifier != 0) {
+        len = nextSpecifier - format;
+      } else {
+        len = strlen(format);
+      }
+      print(format, len);
+      format += len;
+    }
   }
   va_end(args);
 }

--- a/kernel/include/kout.h
+++ b/kernel/include/kout.h
@@ -25,6 +25,6 @@ static inline void print(const char *str) { print(str, strlen(str)); }
 void print(unsigned long value, unsigned long base = 10);
 
 void printf(const char *format, ...);
-}  // namespace kout
+} // namespace kout
 
 #endif

--- a/kernel/include/kout.h
+++ b/kernel/include/kout.h
@@ -17,10 +17,12 @@
 #ifndef _KOUT_H
 #define _KOUT_H
 
+#include <string.h>
+
 namespace kout {
-void print(const char *str);
-void print(unsigned long value, unsigned long base);
-static inline void print(unsigned long value) { print(value, 10); }
+void print(const char *str, int len);
+static inline void print(const char *str) { print(str, strlen(str)); }
+void print(unsigned long value, unsigned long base = 10);
 } // namespace kout
 
 #endif

--- a/kernel/include/kout.h
+++ b/kernel/include/kout.h
@@ -23,6 +23,8 @@ namespace kout {
 void print(const char *str, int len);
 static inline void print(const char *str) { print(str, strlen(str)); }
 void print(unsigned long value, unsigned long base = 10);
-} // namespace kout
+
+void printf(const char *format, ...);
+}  // namespace kout
 
 #endif

--- a/kernel/include/string.h
+++ b/kernel/include/string.h
@@ -25,6 +25,7 @@ void *memcpy(void *dst, const void *src, size_t size);
 int memcmp(const void *a, const void *b, size_t n);
 int strlen(const char *str);
 char *strcpy(char *dst, const char *src);
+char *strchr(const char *str, int c);
 }
 
 static inline bool memeq(const void *a, const void *b, size_t n) {

--- a/kernel/memory/string.cpp
+++ b/kernel/memory/string.cpp
@@ -34,7 +34,7 @@ extern "C" char *strchr(const char *str, int c) {
   int len = strlen(str);
   for (int i = 0; i < len; i++) {
     if (str[i] == chr) {
-      return str + i;
+      return (char *)str + i;
     }
   }
   return 0;

--- a/kernel/memory/string.cpp
+++ b/kernel/memory/string.cpp
@@ -29,3 +29,13 @@ extern "C" char *strcpy(char *dst, const char *src) {
   dst[size] = 0;
   return dst;
 }
+extern "C" char *strchr(const char *str, int c) {
+  char chr = (char)c;
+  int len = strlen(str);
+  for (int i = 0; i < len; i++) {
+    if (str[i] == chr) {
+      return str + i;
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
There used to be no real way of printing formatted text except by writing each print statement individually.

This adds kprintf which supports a minimal subset of the printf specifiers (c, d, l, p, s, n, %).