### PR TITLE
Parse madt table

### DIFF
--- a/kernel/acpi/Make.steps
+++ b/kernel/acpi/Make.steps
@@ -1,1 +1,1 @@
-STEPS+=acpi/tables.o acpi/rsdt.o
+STEPS+=acpi/tables.o acpi/rsdt.o acpi/madt.o

--- a/kernel/acpi/madt.cpp
+++ b/kernel/acpi/madt.cpp
@@ -19,6 +19,8 @@
 
 #include <stddef.h>
 
+#include <kout.h>
+
 namespace acpi {
 MadtTableManager::MadtTableManager(TableHeader *header)
     : TableManager(TableType::MADT) {
@@ -27,6 +29,20 @@ MadtTableManager::MadtTableManager(TableHeader *header)
   hasPic = (madt->flags & MADT_FLAGS_PIC) != 0;
   MadtEntry *entry = (MadtEntry *)((uint8_t *)madt + sizeof(MadtTable));
   while ((size_t)entry - (size_t)madt < madt->header.length) {
+      switch (entry->type) {
+          case MADT_TYPE_LOCAL_APIC: {
+            MadtLocalApicEntry *localApicEntry = (MadtLocalApicEntry *)entry;
+            kout::printf("Found local APIC with id %d\n",
+                         localApicEntry->acpiId);
+                         if (numLocalApics < MAX_LOCAL_APICS) {
+                           localApics[numLocalApics++].apicId =
+                               localApicEntry->apicId;
+                         }
+            break;
+          }
+          default:
+            kout::printf("Unknown MADT entry type %d\n", entry->type);
+      }
     entry = (MadtEntry *)((uint8_t *)entry + entry->length);
   }
 }

--- a/kernel/acpi/madt.cpp
+++ b/kernel/acpi/madt.cpp
@@ -50,9 +50,6 @@ MadtTableManager::MadtTableManager(TableHeader *header)
       }
       break;
     }
-    case MADT_TYPE_GSI_OVERRIDE: {
-      break; // Don't print unnecessary warnings
-    }
     default:
       kout::printf("Unknown MADT entry type %d\n", entry->type);
     }

--- a/kernel/acpi/madt.cpp
+++ b/kernel/acpi/madt.cpp
@@ -14,37 +14,16 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
-#ifndef _ACPI_TABLES_H
-#define _ACPI_TABLES_H
+#include <acpi/madt.h>
+#include <apic.h>
 
-#include <stdint.h>
+#include <stddef.h>
 
 namespace acpi {
-struct TableHeader {
-  char signature[4];
-  uint32_t length;
-  uint8_t revision;
-  uint8_t checksum;
-  char oemId[6];
-  char oemTableId[8];
-  uint32_t oemRevision;
-  char creatorId[4];
-  uint32_t creatorRevision;
-};
-static_assert(sizeof(TableHeader) == 36, "TableHeader incorrect size");
-
-enum class TableType { RSDT, MADT };
-class TableManager {
-public:
-  const TableType type;
-
-  virtual ~TableManager() {}
-
-protected:
-  TableManager(TableType type) : type(type) {}
-};
-
-TableManager *loadTable(void *physicalAddress);
+MadtTableManager::MadtTableManager(TableHeader *header)
+    : TableManager(TableType::MADT) {
+  MadtTable *madt = (MadtTable *)header;
+  localApicAddress = (void *)(size_t)madt->localInterruptController;
+  hasPic = (madt->flags & MADT_FLAGS_PIC) != 0;
+}
 } // namespace acpi
-
-#endif

--- a/kernel/acpi/madt.cpp
+++ b/kernel/acpi/madt.cpp
@@ -25,5 +25,9 @@ MadtTableManager::MadtTableManager(TableHeader *header)
   MadtTable *madt = (MadtTable *)header;
   localApicAddress = (void *)(size_t)madt->localInterruptController;
   hasPic = (madt->flags & MADT_FLAGS_PIC) != 0;
+  MadtEntry *entry = (MadtEntry *)((uint8_t *)madt + sizeof(MadtTable));
+  while ((size_t)entry - (size_t)madt < madt->header.length) {
+    entry = (MadtEntry *)((uint8_t *)entry + entry->length);
+  }
 }
 } // namespace acpi

--- a/kernel/acpi/madt.cpp
+++ b/kernel/acpi/madt.cpp
@@ -33,7 +33,8 @@ MadtTableManager::MadtTableManager(TableHeader *header)
     switch (entry->type) {
     case MADT_TYPE_LOCAL_APIC: {
       MadtLocalApicEntry *localApicEntry = (MadtLocalApicEntry *)entry;
-      if (numLocalApics < MAX_LOCAL_APICS) {
+      if ((localApicEntry->flags & MADT_FLAGS_ENABLED) != 0 &&
+          numLocalApics < MAX_LOCAL_APICS) {
         localApics[numLocalApics++].apicId = localApicEntry->apicId;
       }
       break;
@@ -65,7 +66,7 @@ MadtTableManager::MadtTableManager(TableHeader *header)
     entry = (MadtEntry *)((uint8_t *)entry + entry->length);
   }
   kout::printf("Found %d local APICs, %d io APICs and %d GSI overrides\n",
-              numLocalApics, numIoApics, numGsiOverrides);
+               numLocalApics, numIoApics, numGsiOverrides);
   memory::unmapMemory(header, header->length);
 }
 } // namespace acpi

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -18,6 +18,7 @@
 #include <acpi/tables.h>
 
 #include <acpi/rsdt.h>
+#include <acpi/madt.h>
 
 #include <kmalloc.h>
 #include <kout.h>
@@ -34,8 +35,11 @@ struct TableHandler {
 TableManager *loadRsdt(TableHeader *header) {
   return new RsdtTableManager(header);
 }
+TableManager *loadMadt(TableHeader *header) {
+  return new MadtTableManager(header);
+}
 
-static TableHandler tableHandlers[] = {{"RSDT", loadRsdt}, {"XSDT", loadRsdt}};
+static TableHandler tableHandlers[] = {{"RSDT", loadRsdt}, {"XSDT", loadRsdt}, {"APIC", loadMadt}};
 #define numTableHandlers (sizeof(tableHandlers) / sizeof(TableHandler))
 
 static bool doChecksum(TableHeader *header) {

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -17,8 +17,8 @@
 #include <acpi/rsdp.h>
 #include <acpi/tables.h>
 
-#include <acpi/rsdt.h>
 #include <acpi/madt.h>
+#include <acpi/rsdt.h>
 
 #include <kmalloc.h>
 #include <kout.h>
@@ -39,7 +39,8 @@ TableManager *loadMadt(TableHeader *header) {
   return new MadtTableManager(header);
 }
 
-static TableHandler tableHandlers[] = {{"RSDT", loadRsdt}, {"XSDT", loadRsdt}, {"APIC", loadMadt}};
+static TableHandler tableHandlers[] = {
+    {"RSDT", loadRsdt}, {"XSDT", loadRsdt}, {"APIC", loadMadt}};
 #define numTableHandlers (sizeof(tableHandlers) / sizeof(TableHandler))
 
 static bool doChecksum(TableHeader *header) {

--- a/kernel/include/acpi/madt.h
+++ b/kernel/include/acpi/madt.h
@@ -22,6 +22,13 @@
 #include <apic.h>
 
 namespace acpi {
+  #define MAX_GSI_OVERRIDES 16
+struct MadtGsiOverride {
+  bool levelTriggered;
+  bool activeHigh;
+  uint8_t source;
+  uint32_t destination;
+};
 class MadtTableManager : public TableManager {
 public:
   MadtTableManager(TableHeader *header);
@@ -33,6 +40,8 @@ private:
   apic::LocalApicDescriptor localApics[MAX_LOCAL_APICS];
   unsigned numIoApics = 0;
   apic::IoApicDescriptor ioApics[MAX_IO_APICS];
+  unsigned numGsiOverrides = 0;
+  MadtGsiOverride gsiOverrides[MAX_GSI_OVERRIDES];
 };
 struct __attribute__((packed)) MadtTable {
   TableHeader header;
@@ -71,6 +80,16 @@ struct MadtIoApicEntry {
 };
 static_assert(sizeof(MadtIoApicEntry) == 12,
               "MadtIoApicEntry has not been packed");
+struct __attribute__((packed)) MadtGsiOverrideEntry {
+  uint8_t type;
+  uint8_t length;
+  uint8_t bus;
+  uint8_t source;
+  uint32_t destination;
+  uint16_t flags;
+};
+static_assert(sizeof(MadtGsiOverrideEntry) == 10,
+              "MadtGsiOverrideEntry has not been packed");
 } // namespace acpi
 
 #endif

--- a/kernel/include/acpi/madt.h
+++ b/kernel/include/acpi/madt.h
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _ACPI_MADT_H
+#define _ACPI_MADT_H
+
+#include <acpi/tables.h>
+
+#include <apic.h>
+
+namespace acpi {
+class MadtTableManager : public TableManager {
+public:
+  MadtTableManager(TableHeader *header);
+  virtual ~MadtTableManager();
+
+private:
+  bool hasPic;
+  void *localApicAddress;
+  unsigned numLocalApics = 0;
+  apic::LocalApicDescriptor localApics[MAX_LOCAL_APICS];
+  unsigned numIoApics = 0;
+  apic::IoApicDescriptor ioApics[MAX_IO_APICS];
+};
+struct __attribute__((packed)) MadtTable {
+  TableHeader header;
+  uint32_t localInterruptController;
+  uint32_t flags;
+};
+static_assert(sizeof(MadtTable) == sizeof(TableHeader) + 8,
+              "MadtTable has not been packed");
+#define MADT_FLAGS_PIC (1 << 0)
+struct MadtEntry {
+  uint8_t type;
+  uint8_t length;
+};
+static_assert(sizeof(MadtEntry) == 2, "MadtEntry has not been packed");
+#define MADT_TYPE_LOCAL_APIC 0
+#define MADT_TYPE_IO_APIC 1
+struct MadtLocalApicEntry {
+  uint8_t type;
+  uint8_t length;
+  uint8_t acpiId;
+  uint8_t apicId;
+  uint32_t flags;
+};
+static_assert(sizeof(MadtLocalApicEntry) == 8,
+              "MadtLocalApicEntry has not been packed");
+#define MADT_FLAGS_ENABLED (1 << 0)
+#define MADT_FLAGS_ENABLEABLE (1 << 1)
+struct MadtIoApicEntry {
+  uint8_t type;
+  uint8_t length;
+  uint8_t ioApicId;
+  uint8_t reserved;
+  uint32_t physicalAddress;
+  uint32_t gsiBase;
+};
+static_assert(sizeof(MadtIoApicEntry) == 12,
+              "MadtIoApicEntry has not been packed");
+} // namespace acpi
+
+#endif

--- a/kernel/include/acpi/madt.h
+++ b/kernel/include/acpi/madt.h
@@ -49,6 +49,7 @@ struct MadtEntry {
 static_assert(sizeof(MadtEntry) == 2, "MadtEntry has not been packed");
 #define MADT_TYPE_LOCAL_APIC 0
 #define MADT_TYPE_IO_APIC 1
+#define MADT_TYPE_GSI_OVERRIDE 2
 struct MadtLocalApicEntry {
   uint8_t type;
   uint8_t length;

--- a/kernel/include/acpi/madt.h
+++ b/kernel/include/acpi/madt.h
@@ -25,7 +25,6 @@ namespace acpi {
 class MadtTableManager : public TableManager {
 public:
   MadtTableManager(TableHeader *header);
-  virtual ~MadtTableManager();
 
 private:
   bool hasPic;

--- a/kernel/include/acpi/madt.h
+++ b/kernel/include/acpi/madt.h
@@ -22,7 +22,7 @@
 #include <apic.h>
 
 namespace acpi {
-  #define MAX_GSI_OVERRIDES 16
+#define MAX_GSI_OVERRIDES 16
 struct MadtGsiOverride {
   bool levelTriggered;
   bool activeHigh;

--- a/kernel/include/apic.h
+++ b/kernel/include/apic.h
@@ -1,0 +1,35 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _APIC_H
+#define _APIC_H
+
+#define MAX_LOCAL_APICS 64
+#define MAX_IO_APICS 24
+
+#include <stdint.h>
+
+namespace apic {
+struct LocalApicDescriptor {
+  uint8_t apicId;
+};
+struct IoApicDescriptor {
+  void *physicalAddress;
+  uint32_t gsiBase;
+};
+} // namespace apic
+
+#endif


### PR DESCRIPTION
This adds support for the 'APIC' (madt) table in acpi. This is used to discover processors for smp and to set up the io APICs.