### PR TITLE
Parse hpet table

### DIFF
--- a/kernel/acpi/Make.steps
+++ b/kernel/acpi/Make.steps
@@ -1,1 +1,1 @@
-STEPS+=acpi/tables.o acpi/rsdt.o acpi/madt.o
+STEPS+=acpi/tables.o acpi/rsdt.o acpi/madt.o acpi/hpet.o

--- a/kernel/acpi/hpet.cpp
+++ b/kernel/acpi/hpet.cpp
@@ -17,11 +17,22 @@
 #include <acpi/hpet.h>
 
 #include <kmalloc.h>
+#include <kout.h>
 
 namespace acpi {
 HpetTableManager::HpetTableManager(TableHeader *header)
     : TableManager(TableType::HPET) {
   HpetTable *hpet = (HpetTable *)header;
+  if (hpet->counterSize != 1) {
+    kout::print("Unusable HPET: 32 bit counter\n");
+  } else if (hpet->adress.adressSpace != 0) {
+    kout::print("Unusable HPET: Not memory mapped\n");
+  } else {
+    legacyReplacementCapable = hpet->legacyReplacementCapable;
+    numComparators = hpet->numComparators + 1;
+    physicalAddress = (void *)(size_t)hpet->adress.address;
+    kout::printf("Found HPET with %d comparators\n", numComparators);
+  }
   memory::unmapMemory(header, header->length);
 }
 } // namespace acpi

--- a/kernel/acpi/hpet.cpp
+++ b/kernel/acpi/hpet.cpp
@@ -20,8 +20,8 @@
 
 namespace acpi {
 HpetTableManager::HpetTableManager(TableHeader *header)
-    : type(TableType::HPET) {
-  memory::unmapMemory(header);
-  ;
+    : TableManager(TableType::HPET) {
+  HpetTable *hpet = (HpetTable *)header;
+  memory::unmapMemory(header, header->length);
 }
 } // namespace acpi

--- a/kernel/acpi/hpet.cpp
+++ b/kernel/acpi/hpet.cpp
@@ -14,37 +14,14 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
-#ifndef _ACPI_TABLES_H
-#define _ACPI_TABLES_H
+#include <acpi/hpet.h>
 
-#include <stdint.h>
+#include <kmalloc.h>
 
 namespace acpi {
-struct TableHeader {
-  char signature[4];
-  uint32_t length;
-  uint8_t revision;
-  uint8_t checksum;
-  char oemId[6];
-  char oemTableId[8];
-  uint32_t oemRevision;
-  char creatorId[4];
-  uint32_t creatorRevision;
-};
-static_assert(sizeof(TableHeader) == 36, "TableHeader incorrect size");
-
-enum class TableType { RSDT, MADT, HPET };
-class TableManager {
-public:
-  const TableType type;
-
-  virtual ~TableManager() {}
-
-protected:
-  TableManager(TableType type) : type(type) {}
-};
-
-TableManager *loadTable(void *physicalAddress);
+HpetTableManager::HpetTableManager(TableHeader *header)
+    : type(TableType::HPET) {
+  memory::unmapMemory(header);
+  ;
+}
 } // namespace acpi
-
-#endif

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -17,6 +17,7 @@
 #include <acpi/rsdp.h>
 #include <acpi/tables.h>
 
+#include <acpi/hpet.h>
 #include <acpi/madt.h>
 #include <acpi/rsdt.h>
 
@@ -38,9 +39,12 @@ TableManager *loadRsdt(TableHeader *header) {
 TableManager *loadMadt(TableHeader *header) {
   return new MadtTableManager(header);
 }
+TableManager *loadHpet(TableHeader *header) {
+  return new HpetTableManager(header);
+}
 
 static TableHandler tableHandlers[] = {
-    {"RSDT", loadRsdt}, {"XSDT", loadRsdt}, {"APIC", loadMadt}};
+    {"RSDT", loadRsdt}, {"XSDT", loadRsdt}, {"APIC", loadMadt}, {"HPET", loadHpet}};
 #define numTableHandlers (sizeof(tableHandlers) / sizeof(TableHandler))
 
 static bool doChecksum(TableHeader *header) {

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -43,8 +43,10 @@ TableManager *loadHpet(TableHeader *header) {
   return new HpetTableManager(header);
 }
 
-static TableHandler tableHandlers[] = {
-    {"RSDT", loadRsdt}, {"XSDT", loadRsdt}, {"APIC", loadMadt}, {"HPET", loadHpet}};
+static TableHandler tableHandlers[] = {{"RSDT", loadRsdt},
+                                       {"XSDT", loadRsdt},
+                                       {"APIC", loadMadt},
+                                       {"HPET", loadHpet}};
 #define numTableHandlers (sizeof(tableHandlers) / sizeof(TableHandler))
 
 static bool doChecksum(TableHeader *header) {

--- a/kernel/include/acpi/hpet.h
+++ b/kernel/include/acpi/hpet.h
@@ -14,37 +14,21 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
-#ifndef _ACPI_TABLES_H
-#define _ACPI_TABLES_H
+#ifndef _ACPI_HPET_H
+#define _ACPI_HPET_H
 
-#include <stdint.h>
+#include <acpi/tables.h>
 
 namespace acpi {
-struct TableHeader {
-  char signature[4];
-  uint32_t length;
-  uint8_t revision;
-  uint8_t checksum;
-  char oemId[6];
-  char oemTableId[8];
-  uint32_t oemRevision;
-  char creatorId[4];
-  uint32_t creatorRevision;
-};
-static_assert(sizeof(TableHeader) == 36, "TableHeader incorrect size");
-
-enum class TableType { RSDT, MADT, HPET };
-class TableManager {
+class HpetTableManager : public TableManager {
 public:
-  const TableType type;
+  HpetTableManager(TableHeader *header);
 
-  virtual ~TableManager() {}
-
-protected:
-  TableManager(TableType type) : type(type) {}
+private:
+  void *physicalAddress;
+  uint8_t numComparators;
+  bool legacyReplacement;
 };
-
-TableManager *loadTable(void *physicalAddress);
 } // namespace acpi
 
 #endif

--- a/kernel/include/acpi/hpet.h
+++ b/kernel/include/acpi/hpet.h
@@ -27,7 +27,7 @@ public:
 private:
   void *physicalAddress;
   uint8_t numComparators;
-  bool legacyReplacement;
+  bool legacyReplacementCapable;
 };
 struct __attribute__((packed)) HpetTable {
   TableHeader header;
@@ -35,7 +35,7 @@ struct __attribute__((packed)) HpetTable {
   uint8_t numComparators : 5;
   uint8_t counterSize : 1; // 0 = 32 bits, 1 = 64 bits
   uint8_t reserved : 1;
-  uint8_t legacyReplacement : 1;
+  uint8_t legacyReplacementCapable : 1;
   uint16_t vendorId;
   Address adress;
   uint8_t hpetNumber;

--- a/kernel/include/acpi/hpet.h
+++ b/kernel/include/acpi/hpet.h
@@ -26,7 +26,7 @@ public:
 
 private:
   void *physicalAddress;
-  uint8_t numComparators;
+  uint8_t numComparators = 0;
   bool legacyReplacementCapable;
 };
 struct __attribute__((packed)) HpetTable {

--- a/kernel/include/acpi/hpet.h
+++ b/kernel/include/acpi/hpet.h
@@ -29,6 +29,22 @@ private:
   uint8_t numComparators;
   bool legacyReplacement;
 };
+struct __attribute__((packed)) HpetTable {
+  TableHeader header;
+  uint8_t hardwareRevId;
+  uint8_t numComparators : 5;
+  uint8_t counterSize : 1; // 0 = 32 bits, 1 = 64 bits
+  uint8_t reserved : 1;
+  uint8_t legacyReplacement : 1;
+  uint16_t vendorId;
+  Address adress;
+  uint8_t hpetNumber;
+  uint16_t
+      minimumTicks; // Minimum ticks to not lose interrupts in periodic mode
+  uint8_t pageProtection;
+};
+static_assert(sizeof(HpetTable) == sizeof(TableHeader) + 20,
+              "HpetTable is not packed");
 } // namespace acpi
 
 #endif

--- a/kernel/include/acpi/tables.h
+++ b/kernel/include/acpi/tables.h
@@ -32,6 +32,14 @@ struct TableHeader {
   uint32_t creatorRevision;
 };
 static_assert(sizeof(TableHeader) == 36, "TableHeader incorrect size");
+struct __attribute__((packed)) Address {
+  uint8_t adressSpace;
+  uint8_t bitWidth;
+  uint8_t bitOffset;
+  uint8_t reserved;
+  uint64_t address;
+};
+static_assert(sizeof(Address) == 12, "Address is not packed");
 
 enum class TableType { RSDT, MADT, HPET };
 class TableManager {


### PR DESCRIPTION
The HPET (High Precision Event Timer) is a useful piece of hardware. It allows the kernel to, for example, find out the rate of the TSC (Time-Stamp Counter) for high-precision timing.

It is found through an ACPI table, with a signature of 'HPET'.

This adds a new ACPI table parser which records all useful information from the HPET table.