### PR TITLE
Set up hpet

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -28,6 +28,7 @@ include memory/Make.steps
 include display/Make.steps
 include error/Make.steps
 include acpi/Make.steps
+include drivers/Make.steps
 
 # Enable runtime tests if requested
 ifeq ($(TEST),ON)

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -56,9 +56,11 @@ RsdtTableManager::~RsdtTableManager() {
 
 TableManager *RsdtTableManager::get(TableType type, int num) {
   for (size_t i = 0; i < numChildren; i++) {
-    if (children[i]->type == type) {
-      if (num-- == 0) {
-        return children[i];
+    if (children[i] != nullptr) {
+      if (children[i]->type == type) {
+        if (num-- == 0) {
+          return children[i];
+        }
       }
     }
   }

--- a/kernel/acpi/rsdt.cpp
+++ b/kernel/acpi/rsdt.cpp
@@ -53,4 +53,15 @@ RsdtTableManager::~RsdtTableManager() {
   }
   delete[] children;
 }
+
+TableManager *RsdtTableManager::get(TableType type, int num) {
+  for (size_t i = 0; i < numChildren; i++) {
+    if (children[i]->type == type) {
+      if (num-- == 0) {
+        return children[i];
+      }
+    }
+  }
+  return nullptr;
+}
 } // namespace acpi

--- a/kernel/arch/x86_64/include/mmio.h
+++ b/kernel/arch/x86_64/include/mmio.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Jett Thompson
+    Copyright (C) 2022  Jett Thompson
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,19 +13,23 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
-#ifndef _CPU_H
-#define _CPU_H
+    */
+#ifndef _MMIO_H
+#define _MMIO_H
 
-namespace cpu {
-static inline void mfence() { __asm__ volatile("mfence" : : : "memory"); }
-static inline void relax() { __asm__ volatile("pause"); }
-[[noreturn]] static inline void hault() {
-  __asm__ volatile("cli");
-  for (;;) {
-    __asm__ volatile("hlt");
-  }
+#include <stdint.h>
+
+#include <cpu.h>
+
+namespace mmio {
+template <typename T> static inline void write(T *ptr, T value) {
+  cpu::mfence();
+  *ptr = value;
 }
-} // namespace cpu
+template <typename T> static inline T read(T *ptr) {
+  cpu::mfence();
+  return *ptr;
+}
+} // namespace mmio
 
 #endif

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -33,6 +33,8 @@
 #include <acpi/rsdt.h>
 #include <acpi/tables.h>
 
+#include <hpet.h>
+
 typedef void (*ConstructorOrDestructor)();
 
 extern "C" {
@@ -79,6 +81,8 @@ extern "C" [[noreturn]] void kstart() {
     if (hpetTableManager->comparatorCount() == 0) {
       kpanic("No usable HPET found");
     }
+    hpet::Hpet hpet(hpetTableManager->getPhysicalAddress());
+    kout::printf("HPET says current time is %l\n", hpet.nanoTime());
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -82,7 +82,7 @@ extern "C" [[noreturn]] void kstart() {
       kpanic("No usable HPET found");
     }
     hpet::Hpet hpet(hpetTableManager->getPhysicalAddress());
-    kout::printf("HPET says current time is %l\n", hpet.nanoTime());
+    kout::printf("HPET says current time is %l (with precision of %lkHz)\n", hpet.nanoTime(), hpet.getFrequencyKhz());
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -82,7 +82,8 @@ extern "C" [[noreturn]] void kstart() {
       kpanic("No usable HPET found");
     }
     hpet::Hpet hpet(hpetTableManager->getPhysicalAddress());
-    kout::printf("HPET says current time is %l (with precision of %lkHz)\n", hpet.nanoTime(), hpet.getFrequencyKhz());
+    kout::printf("HPET says current time is %lns sinse reset (with precision of %lkHz)\n",
+                 hpet.nanoTime(), hpet.getFrequencyKhz());
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -82,7 +82,8 @@ extern "C" [[noreturn]] void kstart() {
       kpanic("No usable HPET found");
     }
     hpet::Hpet hpet(hpetTableManager->getPhysicalAddress());
-    kout::printf("HPET says current time is %lns sinse reset (with precision of %lkHz)\n",
+    kout::printf("HPET says current time is %lns sinse reset (with precision "
+                 "of %lkHz)\n",
                  hpet.nanoTime(), hpet.getFrequencyKhz());
     kpanic("It all worked");
   } else {

--- a/kernel/drivers/Make.steps
+++ b/kernel/drivers/Make.steps
@@ -1,0 +1,1 @@
+STEPS+=drivers/hpet/hpet.o

--- a/kernel/drivers/hpet/hpet.cpp
+++ b/kernel/drivers/hpet/hpet.cpp
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#include <hpet.h>
+
+#include <kmalloc.h>
+
+#define HPET_REGISTER_GENERAL_CAPABILITIES 0x0
+#define HPET_REGISTER_GENERAL_CONFIGURATION 0x10
+
+#define HPET_CONFIGURATION_ENABLE_BIT (1 << 0)
+#define HPET_CONFIGURATION_LEGACY_BIT (1 << 1)
+
+namespace hpet {
+Hpet::Hpet(void *physicalAddress)
+    : registerPointer(
+          (uint64_t *)memory::mapAddress(physicalAddress, 1024, false)) {
+  frequencyFemtos = readRegister(HPET_REGISTER_GENERAL_CAPABILITIES) >> 32;
+  // Remove legacy mappings
+  writeRegister(HPET_REGISTER_GENERAL_CONFIGURATION,
+                readRegister(HPET_REGISTER_GENERAL_CONFIGURATION) &
+                    ~HPET_CONFIGURATION_LEGACY_BIT);
+  reset();
+}
+Hpet::~Hpet() { memory::unmapMemory(registerPointer, 1024); }
+
+void Hpet::reset() {
+  // Stop the counter
+  writeRegister(HPET_REGISTER_GENERAL_CONFIGURATION,
+                readRegister(HPET_REGISTER_GENERAL_CONFIGURATION) &
+                    ~HPET_CONFIGURATION_ENABLE_BIT);
+  // Set it to 0
+  writeRegister(HPET_REGISTER_COUNTER, 0);
+  // Enable the counter
+  writeRegister(HPET_REGISTER_GENERAL_CONFIGURATION,
+                readRegister(HPET_REGISTER_GENERAL_CONFIGURATION) |
+                    HPET_CONFIGURATION_ENABLE_BIT);
+}
+} // namespace hpet

--- a/kernel/include/acpi/hpet.h
+++ b/kernel/include/acpi/hpet.h
@@ -28,6 +28,10 @@ private:
   void *physicalAddress;
   uint8_t numComparators = 0;
   bool legacyReplacementCapable;
+
+  void *getPhysicalAddress() { return physicalAddress; }
+  uint8_t comparatorCount() { return numComparators; }
+  bool isLegacyReplacementCapable() { return legacyReplacementCapable; }
 };
 struct __attribute__((packed)) HpetTable {
   TableHeader header;

--- a/kernel/include/acpi/hpet.h
+++ b/kernel/include/acpi/hpet.h
@@ -24,14 +24,14 @@ class HpetTableManager : public TableManager {
 public:
   HpetTableManager(TableHeader *header);
 
+  void *getPhysicalAddress() { return physicalAddress; }
+  uint8_t comparatorCount() { return numComparators; }
+  bool isLegacyReplacementCapable() { return legacyReplacementCapable; }
+
 private:
   void *physicalAddress;
   uint8_t numComparators = 0;
   bool legacyReplacementCapable;
-
-  void *getPhysicalAddress() { return physicalAddress; }
-  uint8_t comparatorCount() { return numComparators; }
-  bool isLegacyReplacementCapable() { return legacyReplacementCapable; }
 };
 struct __attribute__((packed)) HpetTable {
   TableHeader header;

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -27,16 +27,16 @@ public:
   RsdtTableManager(TableHeader *header);
   virtual ~RsdtTableManager();
 
-private:
-  TableManager **children;
-  size_t numChildren;
-
   TableManager *operator[](size_t i) {
     return i < numChildren ? children[i] : nullptr;
   }
   size_t childCount() { return numChildren; }
 
   TableManager *get(TableType type, int num = 0);
+
+private:
+  TableManager **children;
+  size_t numChildren;
 };
 } // namespace acpi
 

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -34,6 +34,7 @@ private:
   TableManager *operator[](size_t i) {
     return i < numChildren ? children[i] : nullptr;
   }
+  size_t childCount() { return numChildren; }
 };
 } // namespace acpi
 

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -35,6 +35,8 @@ private:
     return i < numChildren ? children[i] : nullptr;
   }
   size_t childCount() { return numChildren; }
+
+  TableManager *get(TableType type, int num = 0);
 };
 } // namespace acpi
 

--- a/kernel/include/acpi/rsdt.h
+++ b/kernel/include/acpi/rsdt.h
@@ -30,6 +30,10 @@ public:
 private:
   TableManager **children;
   size_t numChildren;
+
+  TableManager *operator[](size_t i) {
+    return i < numChildren ? children[i] : nullptr;
+  }
 };
 } // namespace acpi
 

--- a/kernel/include/hpet.h
+++ b/kernel/include/hpet.h
@@ -36,6 +36,7 @@ public:
   uint64_t nanoTime() {
     return (readRegister(HPET_REGISTER_COUNTER) * frequencyFemtos) / 1000000;
   }
+  uint64_t getFrequencyKhz() { return 1000000000000l / frequencyFemtos; }
 
   void reset();
 

--- a/kernel/include/hpet.h
+++ b/kernel/include/hpet.h
@@ -30,6 +30,9 @@ public:
   Hpet(void *physicalAddress);
   ~Hpet();
 
+  Hpet(Hpet &other) = delete;
+  Hpet &operator=(Hpet &other) = delete;
+
   uint64_t nanoTime() {
     return (readRegister(HPET_REGISTER_COUNTER) * frequencyFemtos) / 1000000;
   }

--- a/kernel/include/hpet.h
+++ b/kernel/include/hpet.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021  Jett Thompson
+    Copyright (C) 2022  Jett Thompson
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -13,19 +13,35 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
-#ifndef _CPU_H
-#define _CPU_H
+    */
+#ifndef _HPET_H
+#define _HPET_H
 
-namespace cpu {
-static inline void mfence() { __asm__ volatile("mfence" : : : "memory"); }
-static inline void relax() { __asm__ volatile("pause"); }
-[[noreturn]] static inline void hault() {
-  __asm__ volatile("cli");
-  for (;;) {
-    __asm__ volatile("hlt");
+#include <stddef.h>
+#include <stdint.h>
+
+#include <kmalloc.h>
+
+#include <mmio.h>
+
+namespace hpet {
+class Hpet {
+public:
+  Hpet(void *physicalAddress)
+      : registerPointer(
+            (uint64_t *)memory::mapAddress(physicalAddress, 1024, false)) {}
+  ~Hpet() { memory::unmapMemory(registerPointer, 1024); }
+
+private:
+  uint64_t *registerPointer;
+  
+  void writeRegister(size_t offset, uint64_t value) {
+    mmio::write(registerPointer + (offset / 8), value);
   }
-}
-} // namespace cpu
+  uint64_t readRegister(size_t offset) {
+    return mmio::read(registerPointer + (offset / 8));
+  }
+};
+} // namespace hpet
 
 #endif

--- a/kernel/include/hpet.h
+++ b/kernel/include/hpet.h
@@ -20,21 +20,27 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <kmalloc.h>
-
 #include <mmio.h>
+
+#define HPET_REGISTER_COUNTER 0xf0
 
 namespace hpet {
 class Hpet {
 public:
-  Hpet(void *physicalAddress)
-      : registerPointer(
-            (uint64_t *)memory::mapAddress(physicalAddress, 1024, false)) {}
-  ~Hpet() { memory::unmapMemory(registerPointer, 1024); }
+  Hpet(void *physicalAddress);
+  ~Hpet();
+
+  uint64_t nanoTime() {
+    return (readRegister(HPET_REGISTER_COUNTER) * frequencyFemtos) / 1000000;
+  }
+
+  void reset();
 
 private:
   uint64_t *registerPointer;
-  
+
+  uint64_t frequencyFemtos;
+
   void writeRegister(size_t offset, uint64_t value) {
     mmio::write(registerPointer + (offset / 8), value);
   }


### PR DESCRIPTION
The HPET is useful as a source of real time in a kernel.

This adds a driver for the HPET, and it is set up with the first one in the system.