### PR TITLE
Enable multiple processors

### DIFF
--- a/kernel/arch/x86_64/Make.properties
+++ b/kernel/arch/x86_64/Make.properties
@@ -1,1 +1,3 @@
 CXXFLAGS+=-mno-red-zone -mno-sse -mno-sse2 -mno-mmx -mcmodel=large
+#Prevent sections from being aligned on 4k or 2m boundries
+LDFLAGS+=-zmax-page-size=16

--- a/kernel/arch/x86_64/Make.properties
+++ b/kernel/arch/x86_64/Make.properties
@@ -1,3 +1,1 @@
 CXXFLAGS+=-mno-red-zone -mno-sse -mno-sse2 -mno-mmx -mcmodel=large
-#Prevent sections from being aligned on 4k or 2m boundries
-LDFLAGS+=-zmax-page-size=16

--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -5,3 +5,4 @@ STEPS+=arch/x86_64/kernel/memory/copying.o
 STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/interruptHandlers.o
 STEPS+=arch/x86_64/kernel/exceptions/exceptionHandlers.o
 STEPS+=arch/x86_64/kernel/apic/apic.o
+STEPS+=arch/x86_64/kernel/smp/smp.o

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -146,5 +146,5 @@ initial_stack_top:
 .section .smp-trampoline, "ax"
 .code16
 cli
-1: hlt
+1:
 jmp 1b

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -158,7 +158,7 @@ smpIdtPointer:
 .quad 0 /*Null pointer*/
 
 .align 8
-/*Set up the segment registers and load the gdt/idt*/
+/*Set up the segment registers and load the idt*/
 movw %cs, %ax
 movw %ax, %ds
 lidt (0x8012)

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -142,3 +142,9 @@ gdt_end:
 initial_stack:
 .fill 65536 /*Should be fine*/
 initial_stack_top:
+
+.section .smp-trampoline, "ax"
+.code16
+cli
+1: hlt
+jmp 1b

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -144,7 +144,53 @@ initial_stack:
 initial_stack_top:
 
 .section .smp-trampoline, "ax"
+.globl smpTrampolineStart
+smpTrampolineStart:
 .code16
-cli
-1:
-jmp 1b
+jmp $0, $0x8020
+
+.align 8
+smpGdtPointer:
+.word gdt_end - gdt - 1 /*Size - 1*/
+.quad gdt /*Pointer*/
+smpIdtPointer:
+.word 0 /*Zero limit causes tripple fault*/
+.quad 0 /*Null pointer*/
+
+.align 8
+/*Set up the segment registers and load the gdt/idt*/
+movw %cs, %ax
+movw %ax, %ds
+lidt (0x8012)
+
+/*Load the page table*/
+movl $pml4, %esi
+movl %esi, %cr3
+
+/*Enable PAE, LME, PG and PE*/
+/*PAE*/
+movl %cr4, %eax
+orl $(1 << 5), %eax /*PAE bit*/
+movl %eax, %cr4 /*PAE enabled*/
+/*LME*/
+movl $0xC0000080, %ecx /*EFER (Extended Feature Enable Register)*/
+rdmsr /*Get EFER register*/
+orl $(1 << 8), %eax /*Set bit 8 (LME, Long Mode Enable)*/
+wrmsr /*Enable long mode*/
+/*PG and PE*/
+movl %cr0, %eax
+orl $(1 << 31) | (1 << 0), %eax /*PG (paging) bit and PE (Protection Enable) bit*/
+movl %eax, %cr0 /*Paging and protected mode enabled*/
+/*Load the gdt and leave real mode*/
+lgdt (0x8008)
+jmp $8, $0x8080
+
+.code64
+
+.align 128
+movabsq $runningCpus, %rdi
+lock incq (%rdi) /*Tell the smp init code that all is well*/
+1: hlt
+jmp * 1b(%rip)
+.globl smpTrampolineEnd
+smpTrampolineEnd:

--- a/kernel/arch/x86_64/include/apic.h
+++ b/kernel/arch/x86_64/include/apic.h
@@ -42,6 +42,15 @@ struct IoApicDescriptor {
 
 #define LOCAL_APIC_SPURIOUS_INTERRUPT_VECTOR 0xff
 
+#define APIC_FIXED_IPI 0
+#define APIC_LOWEST_PRIORITY_IPI 1
+#define APIC_SMI_IPI 2
+#define APIC_REMOTE_READ_IPI 3
+#define APIC_NMI_IPI 4
+#define APIC_INIT_IPI 5
+#define APIC_STARTUP_IPI 6
+#define APIC_EXTERNAL_INTERRUPT_IPI 7
+
 class LocalApic {
 public:
   void init(void *physicalAddress);

--- a/kernel/arch/x86_64/include/apic.h
+++ b/kernel/arch/x86_64/include/apic.h
@@ -36,6 +36,7 @@ struct IoApicDescriptor {
 };
 
 #define LOCAL_APIC_VERSION_REGISTER 0x30
+#define LOCAL_APIC_ERROR_REGISTER 0x280
 
 #define LOCAL_APIC_VERSION_MASK 0xFF
 
@@ -49,7 +50,12 @@ public:
     return readRegister(LOCAL_APIC_VERSION_REGISTER) & LOCAL_APIC_VERSION_MASK;
   }
 
-private:
+  void clearErrors() { writeRegister(LOCAL_APIC_ERROR_REGISTER, 0); }
+
+  void sendIpi(uint8_t vector, uint8_t messageType, bool logicalDestination,
+               bool assert, bool levelTriggered, uint8_t destinationApicId);
+
+ private:
   uint32_t *registers = nullptr;
 
   void writeRegister(size_t offset, uint32_t value) {

--- a/kernel/arch/x86_64/include/apic.h
+++ b/kernel/arch/x86_64/include/apic.h
@@ -37,8 +37,10 @@ struct IoApicDescriptor {
 
 #define LOCAL_APIC_VERSION_REGISTER 0x30
 #define LOCAL_APIC_ERROR_REGISTER 0x280
+#define LOCAL_APIC_ID_REGISTER 0x20
 
 #define LOCAL_APIC_VERSION_MASK 0xFF
+#define LOCAL_APIC_ID_POSITION 24
 
 #define LOCAL_APIC_SPURIOUS_INTERRUPT_VECTOR 0xff
 
@@ -58,13 +60,16 @@ public:
   uint32_t getVersion() {
     return readRegister(LOCAL_APIC_VERSION_REGISTER) & LOCAL_APIC_VERSION_MASK;
   }
+  uint8_t getApicId() {
+    return readRegister(LOCAL_APIC_ID_REGISTER) >> LOCAL_APIC_ID_POSITION;
+  }
 
   void clearErrors() { writeRegister(LOCAL_APIC_ERROR_REGISTER, 0); }
 
   void sendIpi(uint8_t vector, uint8_t messageType, bool logicalDestination,
                bool assert, bool levelTriggered, uint8_t destinationApicId);
 
- private:
+private:
   uint32_t *registers = nullptr;
 
   void writeRegister(size_t offset, uint32_t value) {

--- a/kernel/arch/x86_64/include/smp.h
+++ b/kernel/arch/x86_64/include/smp.h
@@ -1,0 +1,27 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _SMP_H
+#define _SMP_H
+
+#include <hpet.h>
+#include <stdint.h>
+
+namespace smp {
+bool startCpu(uint8_t apicId, hpet::Hpet &hpet);
+}
+
+#endif

--- a/kernel/arch/x86_64/kernel/smp/smp.cpp
+++ b/kernel/arch/x86_64/kernel/smp/smp.cpp
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#include <smp.h>
+
+#include <apic.h>
+
+extern "C" {
+volatile uint8_t runningCpus = 1;
+}
+
+#define SMP_TRAMPOLINE_PAGE 8
+
+namespace smp {
+bool startCpu(uint8_t apicId, hpet::Hpet &hpet) {
+  uint8_t previousRunningCpus = runningCpus;
+  // Send the init ipi
+  apic::localApic.clearErrors();
+  apic::localApic.sendIpi(0, APIC_INIT_IPI, false, true, false, apicId);
+  // Wait for 10 milliseconds
+  hpet.wait(10000000);
+  // Send the first sipi
+  apic::localApic.clearErrors();
+  apic::localApic.sendIpi(SMP_TRAMPOLINE_PAGE, APIC_STARTUP_IPI, false, true,
+                          false, apicId);
+  // Wait for 1 millisecond
+  hpet.wait(1000000);
+  // Check if the cpu incremented the runningCpus counter
+  if (runningCpus > previousRunningCpus) {
+    return true;
+  } else {
+    // Send the second sipi
+    apic::localApic.clearErrors();
+    apic::localApic.sendIpi(SMP_TRAMPOLINE_PAGE, APIC_STARTUP_IPI, false, true,
+                            false, apicId);
+    // Poll for an incremented runningCpus with a timeout of 1 second
+    uint64_t pollStart = hpet.nanoTime();
+    while (runningCpus == previousRunningCpus &&
+           hpet.nanoTime() < pollStart + 1000000000) {
+      cpu::relax();
+    }
+  }
+  return previousRunningCpus < runningCpus;
+}
+} // namespace smp

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -120,6 +120,8 @@ extern "C" [[noreturn]] void kstart() {
             kout::printf("CPU %d failed to start\n", i);
             kpanic("Error starting CPUs");
           }
+        } else {
+          kout::printf("I am CPU %d\n", i);
         }
       }
     }

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -108,7 +108,7 @@ extern "C" [[noreturn]] void kstart() {
       size_t smpTrampolineSize =
           (size_t)&smpTrampolineEnd - (size_t)&smpTrampolineStart;
       memcpy(smpTrampolineDestination, &smpTrampolineStart, smpTrampolineSize);
-      memory::unmapMemory(smpTrampolineDestination, 4096);
+      memory::unmapMemory(smpTrampolineDestination, 0x1000);
       kout::print("Beginning SMP initialization\n");
       uint8_t myApicId = apic::localApic.getApicId();
       for (unsigned i = 0; i < madt->localApicCount(); i++) {

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -22,11 +22,6 @@ kernelVirtualOffset = 0xFFFF800000000000;
 kernelHeapSize = 512m;
 
 SECTIONS {
-    /*Put this at the start of the binary to remove linker warnings*/
-    . = 0x8000;
-    .smp-trampoline : {
-        KEEP(*(.smp-trampoline));
-    }
     . = 0x200000 + SIZEOF_HEADERS;
     kernelPhysicalAddress = .;
     kernelVirtualAddress = . + kernelVirtualOffset;
@@ -45,6 +40,7 @@ SECTIONS {
     . += kernelVirtualOffset;
     .text : AT(ADDR(.text) - kernelVirtualOffset) {
         *(.text*);
+        KEEP(*(.smp-trampoline));
     }
     .rodata : AT(ADDR(.rodata) - kernelVirtualOffset) {
         *(.rodata*);

--- a/kernel/arch/x86_64/linker.ld
+++ b/kernel/arch/x86_64/linker.ld
@@ -22,6 +22,11 @@ kernelVirtualOffset = 0xFFFF800000000000;
 kernelHeapSize = 512m;
 
 SECTIONS {
+    /*Put this at the start of the binary to remove linker warnings*/
+    . = 0x8000;
+    .smp-trampoline : {
+        KEEP(*(.smp-trampoline));
+    }
     . = 0x200000 + SIZEOF_HEADERS;
     kernelPhysicalAddress = .;
     kernelVirtualAddress = . + kernelVirtualOffset;

--- a/kernel/include/hpet.h
+++ b/kernel/include/hpet.h
@@ -20,8 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <mmio.h>
 #include <cpu.h>
+#include <mmio.h>
 
 #define HPET_REGISTER_COUNTER 0xf0
 

--- a/kernel/include/hpet.h
+++ b/kernel/include/hpet.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include <mmio.h>
+#include <cpu.h>
 
 #define HPET_REGISTER_COUNTER 0xf0
 
@@ -39,6 +40,13 @@ public:
   uint64_t getFrequencyKhz() { return 1000000000000l / frequencyFemtos; }
 
   void reset();
+
+  void wait(uint64_t nanos) {
+    uint64_t currentNanos = nanoTime();
+    while (nanoTime() < currentNanos + nanos) {
+      cpu::relax();
+    }
+  }
 
 private:
   uint64_t *registerPointer;


### PR DESCRIPTION
This adds support for initialization of multiple processors. Currently, they are just put back into cli; hlt state immediately, but they get put through a bootstrap function which can be changed later.

This is very important as it will mean less rewriting of code in the future to use proper locking etc..