### PR TITLE
Allow allocation without header

### DIFF
--- a/kernel/include/kmalloc.h
+++ b/kernel/include/kmalloc.h
@@ -23,9 +23,13 @@ namespace memory {
 void *kmalloc(size_t size);
 void kfree(void *ptr);
 
-void *allocateMemory(size_t size);
 void *mapAddress(void *physicalAddress, size_t size, bool cacheable);
 void unmapMemory(void *address, size_t size);
+
+void *allocateMemory(size_t size);
+static inline void freeMemory(void *ptr, size_t size) {
+  unmapMemory(ptr, size);
+}
 } // namespace memory
 
 #endif

--- a/kernel/include/kmalloc.h
+++ b/kernel/include/kmalloc.h
@@ -23,6 +23,7 @@ namespace memory {
 void *kmalloc(size_t size);
 void kfree(void *ptr);
 
+void *allocateMemory(size_t size);
 void *mapAddress(void *physicalAddress, size_t size, bool cacheable);
 void unmapMemory(void *address, size_t size);
 } // namespace memory

--- a/kernel/memory/kmalloc.cpp
+++ b/kernel/memory/kmalloc.cpp
@@ -29,7 +29,7 @@ namespace memory {
 struct KmallocHeader {
   size_t size;
 };
-void *kmalloc(size_t size) {
+void *allocateMemory(size_t size) {
   size = PAGE_ALIGN_UP(size + sizeof(KmallocHeader));
   void *ptr = virtualMemory.allocate(size);
   if (ptr == nullptr) {
@@ -40,6 +40,10 @@ void *kmalloc(size_t size) {
                     (void *)(memory::allocateFrame() * PAGE_SIZE),
                     paging::PageTableFlags::WRITABLE, true, true);
   }
+  return ptr;
+}
+void *kmalloc(size_t size) {
+  void *ptr = allocateMemory(size);
   KmallocHeader *headerPtr = (KmallocHeader *)ptr;
   *headerPtr = {.size = size};
   ptr = (void *)(headerPtr + 1);


### PR DESCRIPTION
The only way to dynamically allocate memory in the kernel used to be to call kmalloc. This saved the size of the allocation as a header to the returned pointer.

This adds a new function which does not do this, which will be useful for memory which has a known size and therefore does not need the header.