### PR TITLE
Create initial cpu stacks

### DIFF
--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -192,6 +192,9 @@ movabsq $runningCpus, %rdi
 movl $1, %eax
 lock xaddb %al, (%rdi) /*Tell the smp init code that all is well*/
 /*Our CPU number is now in %rax*/
+/*Get our stack from the initialStackPointer table*/
+movabsq $initialStackPointers, %rsi
+movq (%rsi, %rax,8), %rsp
 
 1: hlt
 jmp * 1b(%rip)

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -189,7 +189,10 @@ jmp $8, $0x8080
 
 .align 128
 movabsq $runningCpus, %rdi
-lock incq (%rdi) /*Tell the smp init code that all is well*/
+movl $1, %eax
+lock xaddb %al, (%rdi) /*Tell the smp init code that all is well*/
+/*Our CPU number is now in %rax*/
+
 1: hlt
 jmp * 1b(%rip)
 .globl smpTrampolineEnd

--- a/kernel/arch/x86_64/include/stacks.h
+++ b/kernel/arch/x86_64/include/stacks.h
@@ -14,15 +14,18 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
     */
-#ifndef _SMP_H
-#define _SMP_H
+#ifndef _STACKS_H
+#define _STACKS_H
 
-#include <hpet.h>
-#include <stdint.h>
+#include <kmalloc.h>
 
-namespace smp {
-bool startCpu(uint8_t apicId, hpet::Hpet &hpet);
-void allocateStacks(unsigned numLocalApics);
-} // namespace smp
+#define DEFAULT_STACK_SIZE 16384
+
+namespace stacks {
+static inline void *allocateStack() {
+  return (void *)((uint8_t *)memory::allocateMemory(DEFAULT_STACK_SIZE) +
+                  DEFAULT_STACK_SIZE);
+}
+} // namespace stacks
 
 #endif

--- a/kernel/arch/x86_64/kernel/smp/smp.cpp
+++ b/kernel/arch/x86_64/kernel/smp/smp.cpp
@@ -18,8 +18,12 @@
 
 #include <apic.h>
 
+#include <stacks.h>
+
 extern "C" {
 volatile uint8_t runningCpus = 1;
+
+void *initialStackPointers[MAX_LOCAL_APICS];
 }
 
 #define SMP_TRAMPOLINE_PAGE 8
@@ -54,5 +58,11 @@ bool startCpu(uint8_t apicId, hpet::Hpet &hpet) {
     }
   }
   return previousRunningCpus < runningCpus;
+}
+void allocateStacks(unsigned numLocalApics) {
+  // Allocate stacks for CPUs 1..numLocalApics - 1 (not for the bsp)
+  for (unsigned i = 1; i < numLocalApics; i++) {
+    initialStackPointers[i] = stacks::allocateStack();
+  }
 }
 } // namespace smp

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -109,6 +109,7 @@ extern "C" [[noreturn]] void kstart() {
           (size_t)&smpTrampolineEnd - (size_t)&smpTrampolineStart;
       memcpy(smpTrampolineDestination, &smpTrampolineStart, smpTrampolineSize);
       memory::unmapMemory(smpTrampolineDestination, 0x1000);
+      smp::allocateStacks(madt->localApicCount());
       kout::print("Beginning SMP initialization\n");
       uint8_t myApicId = apic::localApic.getApicId();
       for (unsigned i = 0; i < madt->localApicCount(); i++) {


### PR DESCRIPTION
C++ requires a working stack to function. Sinse each CPU may run in paralell, they are not able to run on the same stack. For this reason, it is necessary to have some way of the CPUs to find out which stack is their's, and use it to call C++ code.

This adds support for this, and also adds support for a "CPU number" which is a unique identifier for each CPU, where the BSP always has CPU number 0. This is used as the index into the initialStackTable.