### PR TITLE
Initialize all local apics

### DIFF
--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -188,15 +188,15 @@ jmp $8, $0x8080
 .code64
 
 .align 128
-movabsq $runningCpus, %rdi
-movl $1, %eax
-lock xaddb %al, (%rdi) /*Tell the smp init code that all is well*/
-/*Our CPU number is now in %rax*/
-
 /*Enable caching*/
 movq %cr0, %rdx
 andq $~(1 << 30), %rdx
 movq %rdx, %cr0
+
+movabsq $runningCpus, %rdi
+movl $1, %eax
+lock xaddb %al, (%rdi) /*Tell the smp init code that all is well*/
+/*Our CPU number is now in %rax*/
 
 /*Get our stack from the initialStackPointer table*/
 movabsq $initialStackPointers, %rsi

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -198,6 +198,17 @@ movl $1, %eax
 lock xaddb %al, (%rdi) /*Tell the smp init code that all is well*/
 /*Our CPU number is now in %rax*/
 
+/*Reload the gdt (see begin_long_mode above)*/
+lgdt (gdt_pointer)
+
+/*Set up the segment registers*/
+xorl %edx, %edx
+movw %dx, %ds
+movw %dx, %es
+movw %dx, %fs
+movw %dx, %gs
+movw %dx, %ss
+
 /*Get our stack from the initialStackPointer table*/
 movabsq $initialStackPointers, %rsi
 movq (%rsi, %rax,8), %rsp

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -192,6 +192,12 @@ movabsq $runningCpus, %rdi
 movl $1, %eax
 lock xaddb %al, (%rdi) /*Tell the smp init code that all is well*/
 /*Our CPU number is now in %rax*/
+
+/*Enable caching*/
+movq %cr0, %rdx
+andq $~(1 << 30), %rdx
+movq %rdx, %cr0
+
 /*Get our stack from the initialStackPointer table*/
 movabsq $initialStackPointers, %rsi
 movq (%rsi, %rax,8), %rsp

--- a/kernel/arch/x86_64/bootstrap/bootstrap.S
+++ b/kernel/arch/x86_64/bootstrap/bootstrap.S
@@ -213,7 +213,8 @@ movw %dx, %ss
 movabsq $initialStackPointers, %rsi
 movq (%rsi, %rax,8), %rsp
 
-1: hlt
-jmp * 1b(%rip)
+movq %rax, %rdi
+movabsq $kstartApCpu, %rax
+jmpq * %rax
 .globl smpTrampolineEnd
 smpTrampolineEnd:

--- a/kernel/arch/x86_64/include/apic.h
+++ b/kernel/arch/x86_64/include/apic.h
@@ -57,6 +57,8 @@ class LocalApic {
 public:
   void init(void *physicalAddress);
 
+  void enable();
+
   uint32_t getVersion() {
     return readRegister(LOCAL_APIC_VERSION_REGISTER) & LOCAL_APIC_VERSION_MASK;
   }

--- a/kernel/arch/x86_64/include/interrupts.h
+++ b/kernel/arch/x86_64/include/interrupts.h
@@ -20,6 +20,6 @@
 namespace interrupts {
 void init();
 void install();
-}  // namespace interrupts
+} // namespace interrupts
 
 #endif

--- a/kernel/arch/x86_64/include/interrupts.h
+++ b/kernel/arch/x86_64/include/interrupts.h
@@ -19,6 +19,7 @@
 
 namespace interrupts {
 void init();
-}
+void install();
+}  // namespace interrupts
 
 #endif

--- a/kernel/arch/x86_64/kernel/apic/apic.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apic.cpp
@@ -28,11 +28,15 @@ LocalApic localApic;
 void LocalApic::init(void *physicalAddress) {
   if (registers == nullptr) {
     registers = (uint32_t *)memory::mapAddress(physicalAddress, 4096, false);
-    writeRegister(LOCAL_APIC_SPURIOUS_INTERRUPT_REGISTER,
-                  LOCAL_APIC_SPURIOUS_INTERRUPT_VECTOR |
-                      LOCAL_APIC_SPURIOUS_INTERRUPT_REGISTER_ENABLE);
   }
 }
+
+void LocalApic::enable() {
+  writeRegister(LOCAL_APIC_SPURIOUS_INTERRUPT_REGISTER,
+                LOCAL_APIC_SPURIOUS_INTERRUPT_VECTOR |
+                    LOCAL_APIC_SPURIOUS_INTERRUPT_REGISTER_ENABLE);
+}
+
 void LocalApic::sendIpi(uint8_t vector, uint8_t messageType,
                         bool logicalDestination, bool assert,
                         bool levelTriggered, uint8_t destinationApicId) {

--- a/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
+++ b/kernel/arch/x86_64/kernel/interrupts/interrupts.cpp
@@ -34,6 +34,6 @@ void init() {
   }
   idtPointer.pointer = idt;
   idtPointer.limit = sizeof(idt) - 1;
-  __asm__ volatile("lidt %0" : : "m"(idtPointer) : "memory");
 }
+void install() { __asm__ volatile("lidt %0" : : "m"(idtPointer) : "memory"); }
 } // namespace interrupts

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -62,6 +62,7 @@ extern "C" [[noreturn]] void kstart() {
   paging::initPageTables();
   display::initFrameBuffer();
   interrupts::init();
+  interrupts::install();
   kout::print("Initialized the console\n\n");
   if (test::runTests(kout::print)) {
     // Continue
@@ -99,6 +100,7 @@ extern "C" [[noreturn]] void kstart() {
       kpanic("No MADT found");
     }
     apic::localApic.init(madt->getLocalApicAddress());
+    apic::localApic.enable();
     kout::printf("Initialized local APIC with version %x\n",
                  apic::localApic.getVersion());
     if (madt->localApicCount() > 1) {
@@ -131,4 +133,12 @@ extern "C" [[noreturn]] void kstart() {
     // The tests failed! Abort
     kpanic("The tests failed!");
   }
+}
+
+extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
+  interrupts::install();
+  apic::localApic.enable();
+  // TODO: Do something with cpuNumber
+  (void)cpuNumber; // Suppress warnings
+  cpu::hault();
 }


### PR DESCRIPTION
The AP CPUs need to initialize their local APICs before they can do much multiprocessor coordination.

This makes each AP CPU initialize its own local apic and install the interrupt handlers. It also enables the caches for the CPU, which is necessary for performance reasons.