### PR TITLE
Make spinlock disable irqs

### DIFF
--- a/kernel/arch/x86_64/include/cpu.h
+++ b/kernel/arch/x86_64/include/cpu.h
@@ -17,7 +17,29 @@
 #ifndef _CPU_H
 #define _CPU_H
 
+#include <stdint.h>
+
 namespace cpu {
+static inline uint64_t getFlags() {
+  uint64_t result;
+  __asm__ volatile("pushfq;"
+                   "popq %0"
+                   : "=g"(result)
+                   :
+                   : "memory");
+  return result;
+}
+static inline void setFlags(uint64_t flags) {
+  __asm__ volatile("pushq %0;"
+                   "popfq"
+                   :
+                   : "g"(flags)
+                   : "memory", "cc");
+}
+static inline bool localIrqState() { return (getFlags() & (1 << 9)) != 0; }
+static inline void enableLocalIrqs() { setFlags(getFlags() | (1 << 9)); }
+static inline void disableLocalIrqs() { setFlags(getFlags() & ~(1 << 9)); }
+
 static inline void mfence() { __asm__ volatile("mfence" : : : "memory"); }
 static inline void relax() { __asm__ volatile("pause"); }
 [[noreturn]] static inline void hault() {

--- a/kernel/include/spinlock.h
+++ b/kernel/include/spinlock.h
@@ -48,8 +48,9 @@ public:
     enableIrqs = oldIrqState;
   }
   void release() {
+    bool shouldReenableIrqs = enableIrqs;
     __atomic_store_n(&lock, 0, __ATOMIC_SEQ_CST);
-    if (enableIrqs) {
+    if (shouldReenableIrqs) {
       cpu::enableLocalIrqs();
     }
   }

--- a/kernel/include/spinlock.h
+++ b/kernel/include/spinlock.h
@@ -36,6 +36,7 @@ public:
   bool locked() { return __atomic_load_n(&lock, __ATOMIC_SEQ_CST) != 0; }
   void acquire() {
     bool oldIrqState = cpu::localIrqState();
+    cpu::disableLocalIrqs();
     while (true) {
       while (locked()) {
         cpu::relax();


### PR DESCRIPTION
Spinlocks should disable local IRQs. This is useful when there is a task scheduler (which there is not currently). Disabling local IRQs prevents preemption in critical code sections and makes it impossible for another task to preempt the current one and try to acquire the lock which the first task is holding.

This makes the Spinlock class disable IRQs when attempting to acquire the lock, and re-enable them afterwards if they were enabled before the lock was locked.