### PR TITLE
Disable legacy pic if applicable

### DIFF
--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -1,5 +1,5 @@
 STEPS+=arch/x86_64/bootstrap/multiboot.o arch/x86_64/bootstrap/bootstrap.o
-STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/pageTableInit.o
+STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/pageTableInit.o arch/x86_64/kernel/pic.o
 STEPS+=arch/x86_64/kernel/paging/paging.o
 STEPS+=arch/x86_64/kernel/memory/copying.o
 STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/interruptHandlers.o

--- a/kernel/arch/x86_64/include/ioPorts.h
+++ b/kernel/arch/x86_64/include/ioPorts.h
@@ -21,27 +21,27 @@
 
 namespace io {
 static inline void writePort8(uint8_t value, uint16_t port) {
-  __asm__ volatile("outb %0, %1" : : "a"(value), "d"(port) : "memory");
+  __asm__ volatile("outb %0, %1" : : "a"(value), "nd"(port) : "memory");
 }
 static inline void writePort16(uint16_t value, uint16_t port) {
-  __asm__ volatile("outw %0, %1" : : "a"(value), "d"(port) : "memory");
+  __asm__ volatile("outw %0, %1" : : "a"(value), "nd"(port) : "memory");
 }
 static inline void writePort32(uint32_t value, uint16_t port) {
-  __asm__ volatile("outl %0, %1" : : "a"(value), "d"(port) : "memory");
+  __asm__ volatile("outl %0, %1" : : "a"(value), "nd"(port) : "memory");
 }
 static inline uint8_t readPort8(uint16_t port) {
   uint8_t value;
-  __asm__ volatile("inb %1, %0" : "=a"(value) : "d"(port) : "memory");
+  __asm__ volatile("inb %1, %0" : "=a"(value) : "nd"(port) : "memory");
   return value;
 }
 static inline uint16_t readPort16(uint16_t port) {
   uint16_t value;
-  __asm__ volatile("inw %1, %0" : "=a"(value) : "d"(port) : "memory");
+  __asm__ volatile("inw %1, %0" : "=a"(value) : "nd"(port) : "memory");
   return value;
 }
 static inline uint32_t readPort32(uint16_t port) {
   uint32_t value;
-  __asm__ volatile("inl %1, %0" : "=a"(value) : "d"(port) : "memory");
+  __asm__ volatile("inl %1, %0" : "=a"(value) : "nd"(port) : "memory");
   return value;
 }
 

--- a/kernel/arch/x86_64/include/ioPorts.h
+++ b/kernel/arch/x86_64/include/ioPorts.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 namespace io {
-static inline void writePort8(uint8_t value, uint64_t port) {
+static inline void writePort8(uint8_t value, uint16_t port) {
   __asm__ volatile("outb %0, %1" : : "a"(value), "d"(port) : "memory");
 }
 static inline void writePort16(uint16_t value, uint16_t port) {

--- a/kernel/arch/x86_64/include/ioPorts.h
+++ b/kernel/arch/x86_64/include/ioPorts.h
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _IO_PORTS_H
+#define _IO_PORTS_H
+
+#include <stdint.h>
+
+namespace io {
+static inline void writePort(uint8_t value, uint64_t port) {
+  __asm__ volatile("outb %0, %1" : : "a"(value), "d"(port) : "memory");
+}
+static inline void writePort(uint16_t value, uint16_t port) {
+  __asm__ volatile("outw %0, %1" : : "a"(value), "d"(port) : "memory");
+}
+static inline void writePort(uint32_t value, uint16_t port) {
+  __asm__ volatile("outl %0, %1" : : "a"(value), "d"(port) : "memory");
+}
+uint8_t readPort8(uint16_t port) {
+  uint8_t value;
+  __asm__ volatile("inb %1, %0" : "=a"(value) : "d"(port) : "memory");
+  return value;
+}
+uint16_t readPort16(uint16_t port) {
+  uint16_t value;
+  __asm__ volatile("inw %1, %0" : "=a"(value) : "d"(port) : "memory");
+  return value;
+}
+uint32_t readPort32(uint16_t port) {
+  uint32_t value;
+  __asm__ volatile("inl %1, %0" : "=a"(value) : "d"(port) : "memory");
+  return value;
+}
+} // namespace io
+
+#endif

--- a/kernel/arch/x86_64/include/ioPorts.h
+++ b/kernel/arch/x86_64/include/ioPorts.h
@@ -20,30 +20,32 @@
 #include <stdint.h>
 
 namespace io {
-static inline void writePort(uint8_t value, uint64_t port) {
+static inline void writePort8(uint8_t value, uint64_t port) {
   __asm__ volatile("outb %0, %1" : : "a"(value), "d"(port) : "memory");
 }
-static inline void writePort(uint16_t value, uint16_t port) {
+static inline void writePort16(uint16_t value, uint16_t port) {
   __asm__ volatile("outw %0, %1" : : "a"(value), "d"(port) : "memory");
 }
-static inline void writePort(uint32_t value, uint16_t port) {
+static inline void writePort32(uint32_t value, uint16_t port) {
   __asm__ volatile("outl %0, %1" : : "a"(value), "d"(port) : "memory");
 }
-uint8_t readPort8(uint16_t port) {
+static inline uint8_t readPort8(uint16_t port) {
   uint8_t value;
   __asm__ volatile("inb %1, %0" : "=a"(value) : "d"(port) : "memory");
   return value;
 }
-uint16_t readPort16(uint16_t port) {
+static inline uint16_t readPort16(uint16_t port) {
   uint16_t value;
   __asm__ volatile("inw %1, %0" : "=a"(value) : "d"(port) : "memory");
   return value;
 }
-uint32_t readPort32(uint16_t port) {
+static inline uint32_t readPort32(uint16_t port) {
   uint32_t value;
   __asm__ volatile("inl %1, %0" : "=a"(value) : "d"(port) : "memory");
   return value;
 }
+
+static inline void delay() { writePort8(0, 0x80); }
 } // namespace io
 
 #endif

--- a/kernel/arch/x86_64/include/pic.h
+++ b/kernel/arch/x86_64/include/pic.h
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _PIC_H
+#define _PIC_H
+
+namespace pic {
+void disablePic();
+}
+
+#endif

--- a/kernel/arch/x86_64/kernel/pic.cpp
+++ b/kernel/arch/x86_64/kernel/pic.cpp
@@ -21,26 +21,26 @@
 #define PIC_REMAP_BASE 0xf8
 
 namespace pic {
-    void disablePic() {
-        // Reset the PICs and remap them
-        io::writePort8(0x11, 0x20);
-        io::writePort8(0x11, 0xa0);
-        io::delay();
-        // Remap the PICs
-        io::writePort8(PIC_REMAP_BASE, 0x21);
-        io::writePort8(PIC_REMAP_BASE, 0xa1);
-        io::delay();
-        // Enable them
-        io::writePort8(4, 0x21);
-        io::writePort8(2, 0xa1);
-        io::delay();
-        io::writePort8(1, 0x21);
-        io::writePort8(1, 0xa1);
-        io::delay();
+void disablePic() {
+  // Reset the PICs and remap them
+  io::writePort8(0x11, 0x20);
+  io::writePort8(0x11, 0xa0);
+  io::delay();
+  // Remap the PICs
+  io::writePort8(PIC_REMAP_BASE, 0x21);
+  io::writePort8(PIC_REMAP_BASE, 0xa1);
+  io::delay();
+  // Enable them
+  io::writePort8(4, 0x21);
+  io::writePort8(2, 0xa1);
+  io::delay();
+  io::writePort8(1, 0x21);
+  io::writePort8(1, 0xa1);
+  io::delay();
 
-        // Mask all IRQs
-        io::writePort8(0xff, 0x21);
-        io::writePort8(0xff, 0xa1);
-        io::delay();
-    }
+  // Mask all IRQs
+  io::writePort8(0xff, 0x21);
+  io::writePort8(0xff, 0xa1);
+  io::delay();
 }
+} // namespace pic

--- a/kernel/arch/x86_64/kernel/pic.cpp
+++ b/kernel/arch/x86_64/kernel/pic.cpp
@@ -1,0 +1,46 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#include <pic.h>
+
+#include <ioPorts.h>
+
+#define PIC_REMAP_BASE 0xf8
+
+namespace pic {
+    void disablePic() {
+        // Reset the PICs and remap them
+        io::writePort8(0x11, 0x20);
+        io::writePort8(0x11, 0xa0);
+        io::delay();
+        // Remap the PICs
+        io::writePort8(PIC_REMAP_BASE, 0x21);
+        io::writePort8(PIC_REMAP_BASE, 0xa1);
+        io::delay();
+        // Enable them
+        io::writePort8(4, 0x21);
+        io::writePort8(2, 0xa1);
+        io::delay();
+        io::writePort8(1, 0x21);
+        io::writePort8(1, 0xa1);
+        io::delay();
+
+        // Mask all IRQs
+        io::writePort8(0xff, 0x21);
+        io::writePort8(0xff, 0xa1);
+        io::delay();
+    }
+}

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -105,10 +105,10 @@ extern "C" [[noreturn]] void kstart() {
     apic::localApic.enable();
     kout::printf("Initialized local APIC with version %x\n",
                  apic::localApic.getVersion());
-                 if (madt->getHasPic()) {
-                   kout::print("Disabling legacy PIC\n");
-                   pic::disablePic();
-                 }
+    if (madt->getHasPic()) {
+      kout::print("Disabling legacy PIC\n");
+      pic::disablePic();
+    }
     if (madt->localApicCount() > 1) {
       // Copy smp trampoline to low memory
       void *smpTrampolineDestination =

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -41,6 +41,8 @@
 #include <apic.h>
 #include <smp.h>
 
+#include <pic.h>
+
 typedef void (*ConstructorOrDestructor)();
 
 extern "C" {
@@ -103,6 +105,10 @@ extern "C" [[noreturn]] void kstart() {
     apic::localApic.enable();
     kout::printf("Initialized local APIC with version %x\n",
                  apic::localApic.getVersion());
+                 if (madt->getHasPic()) {
+                   kout::print("Disabling legacy PIC\n");
+                   pic::disablePic();
+                 }
     if (madt->localApicCount() > 1) {
       // Copy smp trampoline to low memory
       void *smpTrampolineDestination =


### PR DESCRIPTION
The PIC was the original interrupt controller on the PC. It has, however, been replaced by the IO APIC.

Sinse we want to use the IO APIC instead of the legacy PIC, we have to disable the PIC manually if it exists.