### PR TITLE
Create thread control block queues

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -29,6 +29,7 @@ include display/Make.steps
 include error/Make.steps
 include acpi/Make.steps
 include drivers/Make.steps
+include scheduler/Make.steps
 
 # Enable runtime tests if requested
 ifeq ($(TEST),ON)

--- a/kernel/include/task/controlBlock.h
+++ b/kernel/include/task/controlBlock.h
@@ -1,0 +1,30 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _TASK_CONTROL_BLOCK_H
+#define _TASK_CONTROL_BLOCK_H
+
+namespace task {
+    struct ControlBlock {
+      void *entryPoint;
+      void *stackPointer;
+      unsigned timeSlice;
+      unsigned priority;
+      ControlBlock *next;
+    };
+    }  // namespace task
+
+#endif

--- a/kernel/include/task/controlBlock.h
+++ b/kernel/include/task/controlBlock.h
@@ -18,13 +18,13 @@
 #define _TASK_CONTROL_BLOCK_H
 
 namespace task {
-    struct ControlBlock {
-      void *entryPoint;
-      void *stackPointer;
-      unsigned timeSlice;
-      unsigned priority;
-      ControlBlock *next;
-    };
-    }  // namespace task
+struct ControlBlock {
+  void *entryPoint;
+  void *stackPointer;
+  unsigned timeSlice;
+  unsigned priority;
+  ControlBlock *next;
+};
+} // namespace task
 
 #endif

--- a/kernel/include/task/taskQueue.h
+++ b/kernel/include/task/taskQueue.h
@@ -41,10 +41,11 @@ public:
     lock.acquire();
     ControlBlock *result = head;
     if (head != nullptr) {
-      head = head->next;
-      if (head == nullptr) {
-        tail = nullptr;
-      }
+        if (head == tail) {
+          head = tail = nullptr;
+        }else {
+          head = head->next;
+        }
     }
     lock.release();
     return result;
@@ -52,7 +53,8 @@ public:
 
 private:
   lock::Spinlock lock;
-  ControlBlock *head, *tail;
+  ControlBlock *head = nullptr;
+  ControlBlock *tail = nullptr;
 };
 } // namespace task
 

--- a/kernel/include/task/taskQueue.h
+++ b/kernel/include/task/taskQueue.h
@@ -41,11 +41,11 @@ public:
     lock.acquire();
     ControlBlock *result = head;
     if (head != nullptr) {
-        if (head == tail) {
-          head = tail = nullptr;
-        }else {
-          head = head->next;
-        }
+      if (head == tail) {
+        head = tail = nullptr;
+      } else {
+        head = head->next;
+      }
     }
     lock.release();
     return result;

--- a/kernel/include/task/taskQueue.h
+++ b/kernel/include/task/taskQueue.h
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _TASK_TASK_QUEUE_H
+#define _TASK_TASK_QUEUE_H
+
+#include <spinlock.h>
+#include <task/controlBlock.h>
+
+namespace task {
+class Queue {
+public:
+  Queue() = default;
+  Queue(const Queue &other) = delete;
+  Queue &operator=(Queue &other) = delete;
+
+  void push(ControlBlock *value) {
+    lock.acquire();
+    if (head == nullptr) {
+      head = tail = value;
+    } else {
+      tail->next = value;
+      tail = value;
+    }
+    lock.release();
+  }
+  ControlBlock *pop() {
+    lock.acquire();
+    ControlBlock *result = head;
+    if (head != nullptr) {
+      head = head->next;
+      if (head == nullptr) {
+        tail = nullptr;
+      }
+    }
+    lock.release();
+    return result;
+  }
+
+private:
+  lock::Spinlock lock;
+  ControlBlock *head, *tail;
+};
+} // namespace task
+
+#endif

--- a/kernel/scheduler/Make.steps
+++ b/kernel/scheduler/Make.steps
@@ -1,0 +1,1 @@
+TEST_STEPS+=scheduler/taskQueue_test.o

--- a/kernel/scheduler/taskQueue_test.cpp
+++ b/kernel/scheduler/taskQueue_test.cpp
@@ -1,0 +1,57 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifdef RUNTIME_TESTS
+#include <task/taskQueue.h>
+
+#include <test.h>
+
+namespace task {
+namespace test {
+bool taskQueueTest(::test::Logger logger) {
+  logger("taskQueueTest:\n");
+  ControlBlock a, b, c;
+  ControlBlock *aPointer = &a;
+  ControlBlock *bPointer = &b;
+  ControlBlock *cPointer = &c;
+  Queue queue;
+  queue.push(aPointer);
+  queue.push(bPointer);
+  queue.push(cPointer);
+  if (queue.pop() != aPointer) {
+    logger("taskQueueTest failed: Popping failed on first element\n");
+    return false;
+  }
+  if (queue.pop() != bPointer) {
+    logger("taskQueueTest failed: Popping failed on second element\n");
+    return false;
+  }
+  if (queue.pop() != cPointer) {
+    logger("taskQueueTest failed: Popping failed on third element\n");
+    return false;
+  }
+  if (queue.pop() != nullptr) {
+    logger("taskQueueTest failed: Popping non-existant element not null\n");
+    return false;
+  }
+  logger("taskQueueTest: Succeeded\n");
+  return true;
+}
+ADD_TEST(taskQueueTest);
+} // namespace test
+} // namespace task
+
+#endif


### PR DESCRIPTION
The task queue is a fifo queue holding task control bloks. It is used by the scheduler to decide which task to run next.

This creates such a structure with a test to ensure it works properly.