### PR TITLE
Find apic timer frequency

### DIFF
--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -4,5 +4,5 @@ STEPS+=arch/x86_64/kernel/paging/paging.o
 STEPS+=arch/x86_64/kernel/memory/copying.o
 STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/interruptHandlers.o
 STEPS+=arch/x86_64/kernel/exceptions/exceptionHandlers.o
-STEPS+=arch/x86_64/kernel/apic/apic.o
+STEPS+=arch/x86_64/kernel/apic/apic.o arch/x86_64/kernel/apic/apicTimer.o
 STEPS+=arch/x86_64/kernel/smp/smp.o

--- a/kernel/arch/x86_64/include/mykonos/apic.h
+++ b/kernel/arch/x86_64/include/mykonos/apic.h
@@ -39,6 +39,9 @@ struct IoApicDescriptor {
 #define LOCAL_APIC_ERROR_REGISTER 0x280
 #define LOCAL_APIC_ID_REGISTER 0x20
 #define LOCAL_APIC_TIMER_LVT_REGISTER 0x320
+#define LOCAL_APIC_TIMER_INITIAL_COUNT_REGISTER 0x380
+#define LOCAL_APIC_TIMER_CURRENT_COUNT_REGISTER 0x390
+#define LOCAL_APIC_TIMER_DIVIDE_REGISTER 0x3e0
 
 #define LOCAL_APIC_VERSION_MASK 0xFF
 #define LOCAL_APIC_ID_POSITION 24
@@ -53,6 +56,17 @@ struct IoApicDescriptor {
 #define APIC_INIT_IPI 5
 #define APIC_STARTUP_IPI 6
 #define APIC_EXTERNAL_INTERRUPT_IPI 7
+
+#define LOCAL_APIC_FIXED_MESSAGE 0x0
+
+#define APIC_DIVIDE_1 0xb
+#define APIC_DIVIDE_2 0x0
+#define APIC_DIVIDE_4 0x1
+#define APIC_DIVIDE_8 0x2
+#define APIC_DIVIDE_16 0x3
+#define APIC_DIVIDE_32 0x8
+#define APIC_DIVIDE_64 0x9
+#define APIC_DIVIDE_128 0xa
 
 class LocalApic {
 public:
@@ -75,6 +89,16 @@ public:
   void writeTimerLvt(bool periodic, bool mask, uint8_t vector) {
     writeLvtRegister(LOCAL_APIC_TIMER_LVT_REGISTER, periodic, mask, false,
                      LOCAL_APIC_FIXED_MESSAGE, vector);
+  }
+
+  void writeTimerInitialCountRegister(uint32_t initialCount) {
+    writeRegister(LOCAL_APIC_TIMER_INITIAL_COUNT_REGISTER, initialCount);
+  }
+  uint32_t getTimerCurrentCount() {
+    return readRegister(LOCAL_APIC_TIMER_CURRENT_COUNT_REGISTER);
+  }
+  void writeTimerDivideRegister(uint8_t divideFlag) {
+    writeRegister(LOCAL_APIC_TIMER_DIVIDE_REGISTER, divideFlag);
   }
 
 private:

--- a/kernel/arch/x86_64/include/mykonos/apic.h
+++ b/kernel/arch/x86_64/include/mykonos/apic.h
@@ -38,6 +38,7 @@ struct IoApicDescriptor {
 #define LOCAL_APIC_VERSION_REGISTER 0x30
 #define LOCAL_APIC_ERROR_REGISTER 0x280
 #define LOCAL_APIC_ID_REGISTER 0x20
+#define LOCAL_APIC_TIMER_LVT_REGISTER 0x320
 
 #define LOCAL_APIC_VERSION_MASK 0xFF
 #define LOCAL_APIC_ID_POSITION 24
@@ -71,6 +72,11 @@ public:
   void sendIpi(uint8_t vector, uint8_t messageType, bool logicalDestination,
                bool assert, bool levelTriggered, uint8_t destinationApicId);
 
+  void writeTimerLvt(bool periodic, bool mask, uint8_t vector) {
+    writeLvtRegister(LOCAL_APIC_TIMER_LVT_REGISTER, periodic, mask, false,
+                     LOCAL_APIC_FIXED_MESSAGE, vector);
+  }
+
 private:
   uint32_t *registers = nullptr;
 
@@ -79,6 +85,15 @@ private:
   }
   uint32_t readRegister(size_t offset) {
     return mmio::read(registers + (offset / 4));
+  }
+
+  void writeLvtRegister(size_t registerOffset, bool timerPeriodic, bool mask,
+                        bool levelTriggered, uint8_t messageType,
+                        uint8_t vector) {
+    writeRegister(registerOffset, ((uint32_t)timerPeriodic << 17) |
+                                      ((uint32_t)mask << 16) |
+                                      ((uint32_t)levelTriggered << 15) |
+                                      ((uint32_t)messageType << 8) | vector);
   }
 };
 

--- a/kernel/arch/x86_64/include/mykonos/apicTimer.h
+++ b/kernel/arch/x86_64/include/mykonos/apicTimer.h
@@ -1,0 +1,27 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#ifndef _MYKONOS_APIC_TIMER_H
+#define _MYKONOS_APIC_TIMER_H
+
+#include <mykonos/hpet.h>
+
+namespace apic {
+unsigned getTimerTicksPer(unsigned nanos, hpet::Hpet &hpet);
+void startTimer(unsigned tickFrequency);
+}  // namespace apic
+
+#endif

--- a/kernel/arch/x86_64/include/mykonos/apicTimer.h
+++ b/kernel/arch/x86_64/include/mykonos/apicTimer.h
@@ -24,6 +24,6 @@
 namespace apic {
 unsigned timerTicksPer(unsigned nanos, hpet::Hpet &hpet);
 void startTimer(unsigned tickFrequency);
-}  // namespace apic
+} // namespace apic
 
 #endif

--- a/kernel/arch/x86_64/include/mykonos/apicTimer.h
+++ b/kernel/arch/x86_64/include/mykonos/apicTimer.h
@@ -19,8 +19,10 @@
 
 #include <mykonos/hpet.h>
 
+#define APIC_TIMER_INTERRUPT 0xf0
+
 namespace apic {
-unsigned getTimerTicksPer(unsigned nanos, hpet::Hpet &hpet);
+unsigned timerTicksPer(unsigned nanos, hpet::Hpet &hpet);
 void startTimer(unsigned tickFrequency);
 }  // namespace apic
 

--- a/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
@@ -17,3 +17,15 @@
 #include <mykonos/apicTimer.h>
 
 #include <mykonos/apic.h>
+
+namespace apic {
+unsigned timerTicksPer(unsigned nanos, hpet::Hpet &hpet) {
+  localApic.writeTimerLvt(false, false, APIC_TIMER_INTERRUPT);
+  localApic.writeTimerDivideRegister(APIC_DIVIDE_16);
+  localApic.writeTimerInitialCountRegister(0xffffffff);
+  hpet.wait(nanos);
+  localApic.writeTimerLvt(false, true, APIC_TIMER_INTERRUPT);
+  uint32_t ticksPassed = 0xffffffff - localApic.getTimerCurrentCount();
+  return ticksPassed * 16;
+}
+} // namespace apic

--- a/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
@@ -1,0 +1,19 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    */
+#include <mykonos/apicTimer.h>
+
+#include <mykonos/apic.h>

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -43,6 +43,8 @@
 
 #include <mykonos/pic.h>
 
+#include <mykonos/apicTimer.h>
+
 typedef void (*ConstructorOrDestructor)();
 
 extern "C" {
@@ -134,6 +136,8 @@ extern "C" [[noreturn]] void kstart() {
         }
       }
     }
+    unsigned ticksPer10ms = apic::timerTicksPer(10000000, hpet);
+    kout::printf("APIC timer runs at %dHz\n", ticksPer10ms * 100);
     kpanic("It all worked");
   } else {
     // The tests failed! Abort


### PR DESCRIPTION
The APIC timer is a useful timer for scheduling as it is local to each CPU. However, its frequency is not standardized, and probably runs at either the core or bus frequency of the CPU.

This adds logic to find the frequency of the APIC timer so it may be used for a future scheduler.