### PR TITLE
Enable local apic timer

### DIFF
--- a/kernel/arch/x86_64/include/mykonos/apic.h
+++ b/kernel/arch/x86_64/include/mykonos/apic.h
@@ -39,6 +39,11 @@ struct IoApicDescriptor {
 #define LOCAL_APIC_ERROR_REGISTER 0x280
 #define LOCAL_APIC_ID_REGISTER 0x20
 #define LOCAL_APIC_TIMER_LVT_REGISTER 0x320
+#define LOCAL_APIC_THERMAL_LVT_REGISTER 0x330
+#define LOCAL_APIC_PERFORMANCE_LVT_REGISTER 0x340
+#define LOCAL_APIC_LINT0_LVT_REGISTER 0x350
+#define LOCAL_APIC_LINT1_LVT_REGISTER 0x360
+#define LOCAL_APIC_ERROR_LVT_REGISTER 0x370
 #define LOCAL_APIC_TIMER_INITIAL_COUNT_REGISTER 0x380
 #define LOCAL_APIC_TIMER_CURRENT_COUNT_REGISTER 0x390
 #define LOCAL_APIC_TIMER_DIVIDE_REGISTER 0x3e0
@@ -101,6 +106,8 @@ public:
     writeRegister(LOCAL_APIC_TIMER_DIVIDE_REGISTER, divideFlag);
   }
 
+  void maskAllInternal();
+
 private:
   uint32_t *registers = nullptr;
 
@@ -118,6 +125,10 @@ private:
                                       ((uint32_t)mask << 16) |
                                       ((uint32_t)levelTriggered << 15) |
                                       ((uint32_t)messageType << 8) | vector);
+  }
+
+  void maskLvtRegister(size_t registerOffset) {
+    writeRegister(registerOffset, readRegister(registerOffset) | (1 << 16));
   }
 };
 

--- a/kernel/arch/x86_64/include/mykonos/apicTimer.h
+++ b/kernel/arch/x86_64/include/mykonos/apicTimer.h
@@ -23,7 +23,7 @@
 
 namespace apic {
 unsigned timerTicksPer(unsigned nanos, hpet::Hpet &hpet);
-void startTimer(unsigned tickFrequency);
+void setUpTimer(unsigned tickFrequency);
 } // namespace apic
 
 #endif

--- a/kernel/arch/x86_64/kernel/apic/apic.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apic.cpp
@@ -53,4 +53,10 @@ void LocalApic::sendIpi(uint8_t vector, uint8_t messageType,
     cpu::relax();
   }
 }
+void LocalApic::maskAllInternal() {
+  maskLvtRegister(LOCAL_APIC_TIMER_LVT_REGISTER);
+  maskLvtRegister(LOCAL_APIC_THERMAL_LVT_REGISTER);
+  maskLvtRegister(LOCAL_APIC_PERFORMANCE_LVT_REGISTER);
+  maskLvtRegister(LOCAL_APIC_ERROR_LVT_REGISTER);
+}
 } // namespace apic

--- a/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
@@ -28,4 +28,9 @@ unsigned timerTicksPer(unsigned nanos, hpet::Hpet &hpet) {
   uint32_t ticksPassed = 0xffffffff - localApic.getTimerCurrentCount();
   return ticksPassed * 16;
 }
+void setUpTimer(unsigned tickFrequency) {
+  apic::localApic.writeTimerLvt(true, false, APIC_TIMER_INTERRUPT);
+  apic::localApic.writeTimerDivideRegister(APIC_DIVIDE_16);
+  apic::localApic.writeTimerInitialCountRegister(tickFrequency);
+}
 } // namespace apic

--- a/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apicTimer.cpp
@@ -31,6 +31,6 @@ unsigned timerTicksPer(unsigned nanos, hpet::Hpet &hpet) {
 void setUpTimer(unsigned tickFrequency) {
   apic::localApic.writeTimerLvt(true, false, APIC_TIMER_INTERRUPT);
   apic::localApic.writeTimerDivideRegister(APIC_DIVIDE_16);
-  apic::localApic.writeTimerInitialCountRegister(tickFrequency);
+  apic::localApic.writeTimerInitialCountRegister(tickFrequency / 16);
 }
 } // namespace apic

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -146,7 +146,6 @@ extern "C" [[noreturn]] void kstart() {
     cpu::enableLocalIrqs();
     // Set up the APIC timer
     apic::setUpTimer(localApicTickSetting);
-    hpet.wait(1000000000);
     kpanic("It all worked");
   } else {
     // The tests failed! Abort

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -138,6 +138,9 @@ extern "C" [[noreturn]] void kstart() {
     }
     unsigned ticksPer10ms = apic::timerTicksPer(10000000, hpet);
     kout::printf("APIC timer runs at %dHz\n", ticksPer10ms * 100);
+    // Mask all internal interrupts so we can start getting timer IRQs
+    apic::localApic.maskAllInternal();
+    cpu::enableLocalIrqs();
     kpanic("It all worked");
   } else {
     // The tests failed! Abort
@@ -148,6 +151,9 @@ extern "C" [[noreturn]] void kstart() {
 extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
   interrupts::install();
   apic::localApic.enable();
+  // Mask all internal interrupts so we can start getting timer IRQs
+  apic::localApic.maskAllInternal();
+  cpu::enableLocalIrqs();
   // TODO: Do something with cpuNumber
   (void)cpuNumber; // Suppress warnings
   cpu::hault();


### PR DESCRIPTION
This enables the local APIC timer. This is used for the scheduler.

It is initialized to fire every 10ms.