### PR TITLE
Protect kout with spinlock

### DIFF
--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -166,7 +166,6 @@ extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
   }
   // Set up the APIC timer
   apic::setUpTimer(localApicTickSetting);
-  // TODO: Do something with cpuNumber
-  (void)cpuNumber; // Suppress warnings
+  // Just hault for now
   cpu::hault();
 }

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -127,9 +127,7 @@ extern "C" [[noreturn]] void kstart() {
       for (unsigned i = 0; i < madt->localApicCount(); i++) {
         uint8_t apicId = madt->getLocalApic(i).apicId;
         if (apicId != myApicId) {
-          if (smp::startCpu(apicId, hpet)) {
-            kout::printf("Started CPU %d\n", i);
-          } else {
+          if (!smp::startCpu(apicId, hpet)) {
             kout::printf("CPU %d failed to start\n", i);
             kpanic("Error starting CPUs");
           }
@@ -157,6 +155,7 @@ extern "C" [[noreturn]] void kstart() {
 
 extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
   interrupts::install();
+  kout::printf("Started CPU %d\n", cpuNumber);
   apic::localApic.enable();
   // Mask all internal interrupts so we can start getting timer IRQs
   apic::localApic.maskAllInternal();

--- a/kernel/display/console/console.cpp
+++ b/kernel/display/console/console.cpp
@@ -134,4 +134,7 @@ void print(unsigned long value, unsigned long base, bool skipLocking) {
   }
   print(buffer, strlen(buffer), skipLocking);
 }
+
+void acquireConsoleLock() { consoleLock.acquire(); }
+void releaseConsoleLock() { consoleLock.release(); }
 } // namespace kout

--- a/kernel/display/console/console.cpp
+++ b/kernel/display/console/console.cpp
@@ -70,8 +70,10 @@ void scrollDown() {
   lastLine[0] = 0;
 }
 
-void print(const char *str, int len) {
-  consoleLock.acquire();
+void print(const char *str, int len, bool skipLocking) {
+  if (!skipLocking) {
+    consoleLock.acquire();
+  }
   if (columns == 0) {
     displayWidth = display::getWidth();
     displayHeight = display::getHeight();
@@ -109,9 +111,11 @@ void print(const char *str, int len) {
     x += fontWidth;
     column++;
   }
-  consoleLock.release();
+  if (!skipLocking) {
+    consoleLock.release();
+  }
 }
-void print(unsigned long value, unsigned long base) {
+void print(unsigned long value, unsigned long base, bool skipLocking) {
   char buffer[sizeof(unsigned long) * 8 + 1];
   unsigned i = 0;
   do {
@@ -128,6 +132,6 @@ void print(unsigned long value, unsigned long base) {
     buffer[i] = buffer[end - i];
     buffer[end - i] = temp;
   }
-  print(buffer);
+  print(buffer, strlen(buffer), skipLocking);
 }
 } // namespace kout

--- a/kernel/display/console/console.cpp
+++ b/kernel/display/console/console.cpp
@@ -23,6 +23,8 @@
 
 #include <mykonos/string.h>
 
+#include <mykonos/spinlock.h>
+
 namespace kout {
 static unsigned line, column;
 static unsigned lines, columns;
@@ -34,6 +36,8 @@ static char *screenBuffer;
 
 static unsigned displayWidth, displayHeight;
 static unsigned fontWidth, fontHeight;
+
+static lock::Spinlock consoleLock;
 
 void scrollDown() {
   unsigned x = 0;
@@ -67,6 +71,7 @@ void scrollDown() {
 }
 
 void print(const char *str, int len) {
+  consoleLock.acquire();
   if (columns == 0) {
     displayWidth = display::getWidth();
     displayHeight = display::getHeight();
@@ -104,6 +109,7 @@ void print(const char *str, int len) {
     x += fontWidth;
     column++;
   }
+  consoleLock.release();
 }
 void print(unsigned long value, unsigned long base) {
   char buffer[sizeof(unsigned long) * 8 + 1];

--- a/kernel/display/console/printf.cpp
+++ b/kernel/display/console/printf.cpp
@@ -24,6 +24,7 @@ namespace kout {
 void printf(const char *format, ...) {
   va_list args;
   va_start(args, format);
+  acquireConsoleLock();
   while (*format != 0) {
     if (*format == '%') {
       format++;
@@ -32,61 +33,62 @@ void printf(const char *format, ...) {
         break;
       }
       case '%': {
-        print("%", 1);
+        print("%", 1, true);
         break;
       }
       case 'c': {
         char c = (char)va_arg(args, int);
-        print(&c, 1);
+        print(&c, 1, true);
         break;
       }
       case 'd': {
         int n = va_arg(args, int);
-        print(n);
+        print(n, 10, true);
         break;
       }
       case 'l': {
         long l = va_arg(args, long);
-        print(l);
+        print(l, 10, true);
         break;
       }
       case 'o': {
         long l = va_arg(args, long);
-        print(l, 8);
+        print(l, 8, true);
         break;
       }
       case 'p': {
         void *ptr = va_arg(args, void *);
-        print("0x");
-        print((unsigned long)ptr, 16);
+        print("0x", strlen("0x"), true);
+        print((unsigned long)ptr, 16, true);
         break;
       }
       case 's': {
         const char *str = va_arg(args, const char *);
-        print(str);
+        print(str, strlen(str), true);
         break;
       }
       case 'x': {
         long l = va_arg(args, long);
-        print(l, 16);
+        print(l, 16, true);
         break;
       }
       default:
-        print("<unknown type specifier>");
+        print("<unknown type specifier>", strlen("<unknown type specifier>"), true);
       }
       format++;
     } else {
       const char *nextSpecifier = strchr(format, '%');
       int len;
-      if (nextSpecifier != 0) {
+      if (nextSpecifier != nullptr) {
         len = nextSpecifier - format;
       } else {
         len = strlen(format);
       }
-      print(format, len);
+      print(format, len, true);
       format += len;
     }
   }
+  releaseConsoleLock();
   va_end(args);
 }
 } // namespace kout

--- a/kernel/display/console/printf.cpp
+++ b/kernel/display/console/printf.cpp
@@ -73,7 +73,8 @@ void printf(const char *format, ...) {
         break;
       }
       default:
-        print("<unknown type specifier>", strlen("<unknown type specifier>"), true);
+        print("<unknown type specifier>", strlen("<unknown type specifier>"),
+              true);
       }
       format++;
     } else {

--- a/kernel/include/mykonos/kout.h
+++ b/kernel/include/mykonos/kout.h
@@ -24,6 +24,9 @@ void print(const char *str, int len, bool skipLocking=false);
 static inline void print(const char *str) { print(str, strlen(str)); }
 void print(unsigned long value, unsigned long base = 10, bool skipLocking=false);
 
+void acquireConsoleLock();
+void releaseConsoleLock();
+
 void printf(const char *format, ...);
 } // namespace kout
 

--- a/kernel/include/mykonos/kout.h
+++ b/kernel/include/mykonos/kout.h
@@ -20,9 +20,9 @@
 #include <mykonos/string.h>
 
 namespace kout {
-void print(const char *str, int len);
+void print(const char *str, int len, bool skipLocking=false);
 static inline void print(const char *str) { print(str, strlen(str)); }
-void print(unsigned long value, unsigned long base = 10);
+void print(unsigned long value, unsigned long base = 10, bool skipLocking=false);
 
 void printf(const char *format, ...);
 } // namespace kout

--- a/kernel/include/mykonos/kout.h
+++ b/kernel/include/mykonos/kout.h
@@ -20,9 +20,10 @@
 #include <mykonos/string.h>
 
 namespace kout {
-void print(const char *str, int len, bool skipLocking=false);
+void print(const char *str, int len, bool skipLocking = false);
 static inline void print(const char *str) { print(str, strlen(str)); }
-void print(unsigned long value, unsigned long base = 10, bool skipLocking=false);
+void print(unsigned long value, unsigned long base = 10,
+           bool skipLocking = false);
 
 void acquireConsoleLock();
 void releaseConsoleLock();


### PR DESCRIPTION
The kout functions (console output) would be quite useful in all situations, including IRQ contexts. For this reason, it makes sense to protect kout with a spinlock, which guarantees synchronization across CPUs and in interrupt contexts (unlike mutexes).

As a test of this synchronization, each CPU prints its own 'starting CPU %d' message when it starts up. This shows that the synchronization works, but it also causes the order of messages to be unexpected, and even overlap with messages from the BSP.