### PR TITLE
Save cpu number

### DIFF
--- a/kernel/arch/x86_64/include/mykonos/cpu.h
+++ b/kernel/arch/x86_64/include/mykonos/cpu.h
@@ -20,10 +20,29 @@
 #include <stdint.h>
 
 namespace cpu {
+static inline uint64_t rdmsr(uint32_t address) {
+  uint32_t msrLow, msrHigh;
+  __asm__ volatile("rdmsr"
+                   : "=a"(msrLow), "=d"(msrHigh)
+                   : "c"(address)
+                   : "memory");
+  return msrLow | ((uint64_t)msrHigh << 32);
+}
+static inline void wrmsr(uint64_t value, uint32_t address) {
+  __asm__ volatile("wrmsr"
+                   : "=a"((uint32_t)value), "=d"((uint32_t)(value >> 32)),
+                     "c"(address)
+                   :
+                   : "memory");
+}
+
 static inline unsigned getCpuNumber() {
   unsigned cpuNumber;
   __asm__ volatile("rdtscp" : "=c"(cpuNumber) : : "rdx", "rax", "memory");
   return cpuNumber;
+}
+static inline void setCpuNumber(unsigned cpuNumber) {
+  wrmsr(cpuNumber, 0xc0000103); // rdtscp processor id
 }
 
 static inline uint64_t getFlags() {

--- a/kernel/arch/x86_64/include/mykonos/cpu.h
+++ b/kernel/arch/x86_64/include/mykonos/cpu.h
@@ -30,9 +30,9 @@ static inline uint64_t rdmsr(uint32_t address) {
 }
 static inline void wrmsr(uint64_t value, uint32_t address) {
   __asm__ volatile("wrmsr"
-                   : "=a"((uint32_t)value), "=d"((uint32_t)(value >> 32)),
-                     "c"(address)
                    :
+                   : "a"((uint32_t)value), "d"((uint32_t)(value >> 32)),
+                     "c"(address)
                    : "memory");
 }
 

--- a/kernel/arch/x86_64/include/mykonos/cpu.h
+++ b/kernel/arch/x86_64/include/mykonos/cpu.h
@@ -20,6 +20,12 @@
 #include <stdint.h>
 
 namespace cpu {
+static inline unsigned getCpuNumber() {
+  unsigned cpuNumber;
+  __asm__ volatile("rdtscp" : "=c"(cpuNumber) : : "rdx", "rax", "memory");
+  return cpuNumber;
+}
+
 static inline uint64_t getFlags() {
   uint64_t result;
   __asm__ volatile("pushfq;"

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -136,6 +136,8 @@ extern "C" [[noreturn]] void kstart() {
         }
       }
     }
+    // Store our CPU number (0 for BSP)
+    cpu::setCpuNumber(0);
     unsigned ticksPer10ms = apic::timerTicksPer(10000000, hpet);
     localApicTickSetting = ticksPer10ms;
     kout::printf("APIC timer runs at %dHz\n", ticksPer10ms * 100);
@@ -154,6 +156,8 @@ extern "C" [[noreturn]] void kstart() {
 }
 
 extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
+  // Store the CPU number for later use
+  cpu::setCpuNumber(cpuNumber);
   interrupts::install();
   kout::printf("Started CPU %d\n", cpuNumber);
   apic::localApic.enable();


### PR DESCRIPTION
The CPU number is very important for things like scheduling. For this reason, it must be possible to get it in any context.

One solution to this is to store the CPU number in the TSC auxiliary MSR (designed for the purpose), and read it with the rdtscp (read time stamp counter and processor ID) instruction.