### PR TITLE
Run callbacks on other cpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export AS:=$(ARCH)-elf-gcc
 export LD:=$(ARCH)-elf-gcc
 
 export CPPFLAGS:=
-export CXXFLAGS:=-std=gnu++17 -nostdlib -O2 -g -ffunction-sections -fdata-sections -Wall -Wextra
+export CXXFLAGS:=-std=gnu++20 -nostdlib -O2 -g -ffunction-sections -fdata-sections -Wall -Wextra
 export ASFLAGS:=
 
 export LDFLAGS:=-nostdlib -lgcc -Wl,--gc-sections

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export AS:=$(ARCH)-elf-gcc
 export LD:=$(ARCH)-elf-gcc
 
 export CPPFLAGS:=
-export CXXFLAGS:=-std=gnu++20 -nostdlib -O2 -g -ffunction-sections -fdata-sections -Wall -Wextra
+export CXXFLAGS:=-std=gnu++17 -nostdlib -O2 -g -ffunction-sections -fdata-sections -Wall -Wextra
 export ASFLAGS:=
 
 export LDFLAGS:=-nostdlib -lgcc -Wl,--gc-sections

--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -6,3 +6,4 @@ STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/
 STEPS+=arch/x86_64/kernel/exceptions/exceptionHandlers.o
 STEPS+=arch/x86_64/kernel/apic/apic.o arch/x86_64/kernel/apic/apicTimer.o
 STEPS+=arch/x86_64/kernel/smp/smp.o
+STEPS+=arch/x86_64/kernel/processors/processors.o

--- a/kernel/arch/x86_64/include/mykonos/apic.h
+++ b/kernel/arch/x86_64/include/mykonos/apic.h
@@ -142,6 +142,8 @@ private:
   }
 };
 
+extern uint8_t localApicIds[MAX_LOCAL_APICS];
+
 extern LocalApic localApic;
 } // namespace apic
 

--- a/kernel/arch/x86_64/include/mykonos/processors.h
+++ b/kernel/arch/x86_64/include/mykonos/processors.h
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_PROCESSORS_H
+#define _MYKONOS_PROCESSORS_H
+
+#define PROCESSOR_CALLBACK_INTERRUPT 0xfe
+
+#include <mykonos/callback.h>
+
+namespace processors {
+// Run the specified callback on CPU cpuNumber. The function returns when the
+// callback returns
+void runOn(unsigned cpuNumber, callback::Callback<void> &&callback);
+
+// Internal function. Called when the CPU receives a request to execute a
+// callback
+void receiveCall();
+} // namespace processors
+
+#endif

--- a/kernel/arch/x86_64/include/mykonos/processors.h
+++ b/kernel/arch/x86_64/include/mykonos/processors.h
@@ -24,7 +24,7 @@
 namespace processors {
 // Run the specified callback on CPU cpuNumber. The function returns when the
 // callback returns
-void runOn(unsigned cpuNumber, callback::Callback<void> &&callback);
+void runOn(unsigned cpuNumber, callback::Callback<bool> &&callback);
 
 // Internal function. Called when the CPU receives a request to execute a
 // callback

--- a/kernel/arch/x86_64/kernel/apic/apic.cpp
+++ b/kernel/arch/x86_64/kernel/apic/apic.cpp
@@ -23,6 +23,8 @@
 #define LOCAL_APIC_SPURIOUS_INTERRUPT_REGISTER_ENABLE (1 << 8)
 
 namespace apic {
+uint8_t localApicIds[MAX_LOCAL_APICS];
+
 LocalApic localApic;
 
 void LocalApic::init(void *physicalAddress) {

--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.cpp
@@ -15,11 +15,16 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <mykonos/apic.h>
+#include <mykonos/processors.h>
 
 #include <stdint.h>
 
 extern "C" void handleInterrupt(uint8_t interruptNumber) {
   switch (interruptNumber) {
+  case PROCESSOR_CALLBACK_INTERRUPT: {
+    processors::receiveCall();
+    break;
+  }
   default:
     break;
   }

--- a/kernel/arch/x86_64/kernel/processors/processors.cpp
+++ b/kernel/arch/x86_64/kernel/processors/processors.cpp
@@ -21,9 +21,9 @@
 #include <mykonos/cpu.h>
 
 namespace processors {
-callback::Callback<void> *mailboxes[MAX_LOCAL_APICS];
+callback::Callback<bool> *mailboxes[MAX_LOCAL_APICS];
 
-void runOn(unsigned cpuNumber, callback::Callback<void> &&callback) {
+void runOn(unsigned cpuNumber, callback::Callback<bool> &&callback) {
   if (cpuNumber < MAX_LOCAL_APICS) {
     // Wait for all previous requests to complete
     while (true) {
@@ -44,6 +44,12 @@ void runOn(unsigned cpuNumber, callback::Callback<void> &&callback) {
     }
     // Clean up
     mailboxes[cpuNumber] = nullptr;
+  }
+}
+void receiveCall() {
+  unsigned cpuNumber = cpu::getCpuNumber();
+  if (mailboxes[cpuNumber] != nullptr) {
+    (*mailboxes[cpuNumber])();
   }
 }
 } // namespace processors

--- a/kernel/arch/x86_64/kernel/processors/processors.cpp
+++ b/kernel/arch/x86_64/kernel/processors/processors.cpp
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/processors.h>
+
+#include <mykonos/apic.h>
+#include <mykonos/callback.h>
+#include <mykonos/cpu.h>
+
+namespace processors {
+callback::Callback<void> *mailboxes[MAX_LOCAL_APICS];
+
+void runOn(unsigned cpuNumber, callback::Callback<void> &&callback) {
+  if (cpuNumber < MAX_LOCAL_APICS) {
+    // Wait for all previous requests to complete
+    while (true) {
+      while (mailboxes[cpuNumber] != nullptr) {
+        cpu::relax();
+      }
+      if (__sync_bool_compare_and_swap(&mailboxes[cpuNumber], nullptr,
+                                       &callback)) {
+        break;
+      }
+    }
+    // Tell the CPU to start executing the request
+    apic::localApic.sendIpi(PROCESSOR_CALLBACK_INTERRUPT, APIC_FIXED_IPI, false,
+                            true, true, apic::localApicIds[cpuNumber]);
+    // Wait for it to be handled
+    while (!callback.hasRun()) {
+      cpu::relax();
+    }
+    // Clean up
+    mailboxes[cpuNumber] = nullptr;
+  }
+}
+} // namespace processors

--- a/kernel/arch/x86_64/kernel/processors/processors.cpp
+++ b/kernel/arch/x86_64/kernel/processors/processors.cpp
@@ -39,7 +39,7 @@ void runOn(unsigned cpuNumber, callback::Callback<bool> &&callback) {
     apic::localApic.sendIpi(PROCESSOR_CALLBACK_INTERRUPT, APIC_FIXED_IPI, false,
                             true, true, apic::localApicIds[cpuNumber]);
     // Wait for it to be handled
-    while (!callback.hasRun()) {
+    while (!mailboxes[cpuNumber]->hasRun()) {
       cpu::relax();
     }
     // Clean up

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -175,7 +175,9 @@ extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
                  cpuNumber);
     return true;
   };
-    processors::runOn(cpuNumber - 1, callback::Lambda<decltype(otherCpuCode), bool>(otherCpuCode));
+  processors::runOn(
+      cpuNumber - 1,
+      callback::Lambda<decltype(otherCpuCode), bool>(otherCpuCode));
   // Wait for the BSP to figure out the APIC setting
   while (localApicTickSetting == 0) {
     cpu::relax();

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -133,6 +133,7 @@ extern "C" [[noreturn]] void kstart() {
           }
         } else {
           kout::printf("I am CPU %d\n", i);
+          apic::localApicIds[0] = apicId;
         }
       }
     }
@@ -158,9 +159,11 @@ extern "C" [[noreturn]] void kstart() {
 extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
   // Store the CPU number for later use
   cpu::setCpuNumber(cpuNumber);
+  apic::localApic.enable();
+  // Store our APIC id for later use
+  apic::localApicIds[cpuNumber] = apic::localApic.getApicId();
   interrupts::install();
   kout::printf("Started CPU %d\n", cpuNumber);
-  apic::localApic.enable();
   // Mask all internal interrupts so we can start getting timer IRQs
   apic::localApic.maskAllInternal();
   cpu::enableLocalIrqs();

--- a/kernel/include/mykonos/callback.h
+++ b/kernel/include/mykonos/callback.h
@@ -29,6 +29,7 @@ public:
     run = true;
     return res;
   }
+  bool hasRun() { return run; }
 };
 
 template <typename LambdaType, typename Result, typename... ParameterTypes>

--- a/kernel/include/mykonos/callback.h
+++ b/kernel/include/mykonos/callback.h
@@ -1,0 +1,44 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_CALLBACK_H
+#define _MYKONOS_CALLBACK_H
+
+namespace callback {
+template <typename Result, typename... ParameterTypes> class Callback {
+private:
+  bool run = false;
+  virtual Result invoke(ParameterTypes...);
+
+public:
+  Result operator()(ParameterTypes... args) {
+    Result res = invoke(args...);
+    run = true;
+    return res;
+  }
+};
+
+template <auto l, typename Result, typename... ParameterTypes>
+class Lambda : public Callback<Result, ParameterTypes...> {
+private:
+  static constexpr auto lambda = l;
+
+public:
+  virtual Result invoke(ParameterTypes... args) { return l(args...); }
+};
+} // namespace callback
+
+#endif

--- a/kernel/include/mykonos/callback.h
+++ b/kernel/include/mykonos/callback.h
@@ -18,6 +18,7 @@
 #define _MYKONOS_CALLBACK_H
 
 namespace callback {
+// Note: Don't use with void return type.
 template <typename Result, typename... ParameterTypes> class Callback {
 private:
   bool run = false;

--- a/kernel/include/mykonos/callback.h
+++ b/kernel/include/mykonos/callback.h
@@ -31,13 +31,16 @@ public:
   }
 };
 
-template <auto l, typename Result, typename... ParameterTypes>
+template <typename LambdaType, typename Result, typename... ParameterTypes>
 class Lambda : public Callback<Result, ParameterTypes...> {
 private:
-  static constexpr auto lambda = l;
+  LambdaType lambda;
 
 public:
-  virtual Result invoke(ParameterTypes... args) { return l(args...); }
+  Lambda<LambdaType, Result, ParameterTypes...>(LambdaType lambda)
+      : lambda(lambda) {}
+
+  virtual Result invoke(ParameterTypes... args) { return lambda(args...); }
 };
 } // namespace callback
 


### PR DESCRIPTION
This allows code to run a callback function (which may be a lambda) on another CPU. This will be useful for things like preempting other CPUs in the scheduler.