### PR TITLE
made the kernel check if rdtscp is supported

### DIFF
--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -1,5 +1,5 @@
 STEPS+=arch/x86_64/bootstrap/multiboot.o arch/x86_64/bootstrap/bootstrap.o
-STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/pageTableInit.o arch/x86_64/kernel/pic.o
+STEPS+=arch/x86_64/kernel/startup.o arch/x86_64/kernel/mbi.o arch/x86_64/kernel/pageTableInit.o arch/x86_64/kernel/pic.o arch/x86_64/kernel/cpuidCheck.o
 STEPS+=arch/x86_64/kernel/paging/paging.o
 STEPS+=arch/x86_64/kernel/memory/copying.o
 STEPS+=arch/x86_64/kernel/interrupts/interrupts.o arch/x86_64/kernel/interrupts/idtHandlers.o arch/x86_64/kernel/interrupts/interruptHandlers.o

--- a/kernel/arch/x86_64/include/mykonos/cpuidCheck.h
+++ b/kernel/arch/x86_64/include/mykonos/cpuidCheck.h
@@ -1,0 +1,24 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_CPUID_CHECK_H
+#define _MYKONOS_CPUID_CHECK_H
+
+namespace cpuid {
+bool checkCpuidFlags();
+}
+
+#endif

--- a/kernel/arch/x86_64/kernel/cpuidCheck.cpp
+++ b/kernel/arch/x86_64/kernel/cpuidCheck.cpp
@@ -1,0 +1,35 @@
+/*
+    Copyright (C) 2022  Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/cpuidCheck.h>
+
+#include <cpuid.h>
+#include <mykonos/kout.h>
+
+#define CPUID_8000_0001_EDX_RDTSCP (1 << 27)
+
+namespace cpuid {
+bool checkCpuidFlags() {
+  unsigned eax = 0, ebx = 0, ecx = 0, edx = 0;
+  // Extended features (fn0x8000_0001)
+  __get_cpuid(0x80000001, &eax, &ebx, &ecx, &edx);
+  if ((edx & CPUID_8000_0001_EDX_RDTSCP) == 0) {
+    kout::print("Your CPU does not support rdtscp\n");
+    return false;
+  }
+  return true;
+}
+} // namespace cpuid

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -22,6 +22,8 @@
 #include <mykonos/frameBuffer.h>
 #include <mykonos/kout.h>
 
+#include <mykonos/cpuidCheck.h>
+
 #include <mykonos/test.h>
 
 #include <mykonos/interrupts.h>
@@ -72,6 +74,9 @@ extern "C" [[noreturn]] void kstart() {
   interrupts::init();
   interrupts::install();
   kout::print("Initialized the console\n\n");
+  if (!cpuid::checkCpuidFlags()) {
+    kpanic("Your CPU is not good enough");
+  }
   if (test::runTests(kout::print)) {
     // Continue
     if (!memeq(acpi::rsdp.signature, "RSD PTR ", 8)) {


### PR DESCRIPTION
There have been some invalid opcode exceptions on qemu which does not support rdtscp by default. This is unfortunate, and very hard to trace.

For this reason, the kernel now checks for rdtscp support early on and panics if it is not supported.