### PR TITLE
made the hpet acpi table driver not care about weather the hpet is 64 bit

### DIFF
--- a/kernel/acpi/hpet.cpp
+++ b/kernel/acpi/hpet.cpp
@@ -23,9 +23,7 @@ namespace acpi {
 HpetTableManager::HpetTableManager(TableHeader *header)
     : TableManager(TableType::HPET) {
   HpetTable *hpet = (HpetTable *)header;
-  if (hpet->counterSize != 1) {
-    kout::print("Unusable HPET: 32 bit counter\n");
-  } else if (hpet->adress.adressSpace != 0) {
+  if (hpet->adress.adressSpace != 0) {
     kout::print("Unusable HPET: Not memory mapped\n");
   } else {
     legacyReplacementCapable = hpet->legacyReplacementCapable;


### PR DESCRIPTION
The HPET ACPI table driver used to stop 32 bit HPETs from being used. This is not necessary however, as the HPET works in almost the exact same way with a 32 bit counter. This removes the restriction.