### PR TITLE
Fix idt to use all entries

### DIFF
--- a/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
@@ -125,7 +125,7 @@ extern "C" void handleCpuException(uint64_t exceptionNumber, uint64_t errorCode,
     break;
   }
   default:
-    kout::printf("Unimplemented exception number\n");
+    kout::print("Unimplemented exception number\n");
     break;
   }
   kpanic("Non recoverable exception caught\n");

--- a/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/exceptions/exceptionHandlers.cpp
@@ -32,9 +32,7 @@ static_assert(sizeof(InterruptStackFrame) == 40,
 
 extern "C" void handleCpuException(uint64_t exceptionNumber, uint64_t errorCode,
                                    InterruptStackFrame *interruptStackFrame) {
-  kout::print("Exception at address 0x");
-  kout::print((unsigned long)interruptStackFrame->rip, 16);
-  kout::print(":\n");
+  kout::printf("Exception at address %p:\n", interruptStackFrame->rip);
   switch (exceptionNumber) {
   case CPU_DE: {
     kout::print("Division exception\n");
@@ -77,9 +75,7 @@ extern "C" void handleCpuException(uint64_t exceptionNumber, uint64_t errorCode,
     break;
   }
   case CPU_NP: {
-    kout::print("Segment not present: ");
-    kout::print(errorCode);
-    kout::print("\n");
+    kout::print("Segment not present: %d\n", errorCode);
     break;
   }
   case CPU_SS: {
@@ -87,19 +83,13 @@ extern "C" void handleCpuException(uint64_t exceptionNumber, uint64_t errorCode,
     break;
   }
   case CPU_GP: {
-    kout::print("General protection fault (0x");
-    kout::print(errorCode, 16);
-    kout::print(")\n");
+    kout::printf("General protection fault (0x%d)\n", errorCode);
     break;
   }
   case CPU_PF: {
-    kout::print("Page fault (");
-    kout::print(errorCode, 2);
-    kout::print(") on address ");
-    void *cr2Address;
-    __asm__ volatile("movq %%cr2, %0" : "=a"(cr2Address));
-    kout::print((unsigned long)cr2Address, 16);
-    kout::print("\n");
+    void *cr2;
+    __asm__ volatile("movq %%cr2, %0" : "=a"(cr2));
+    kout::printf("Page fault (%x) on address %p\n", errorCode, cr2);
     break;
   }
   case CPU_MF: {
@@ -135,7 +125,7 @@ extern "C" void handleCpuException(uint64_t exceptionNumber, uint64_t errorCode,
     break;
   }
   default:
-    kout::print("Unimplemented exception number\n");
+    kout::printf("Unimplemented exception number\n");
     break;
   }
   kpanic("Non recoverable exception caught\n");

--- a/kernel/arch/x86_64/kernel/interrupts/idtHandlers.S
+++ b/kernel/arch/x86_64/kernel/interrupts/idtHandlers.S
@@ -73,7 +73,7 @@ errorCodeExceptionHandler 30 /*#SX: Security exception*/
 reservedExceptions 1
 
 currentInterruptNumber = 32
-.rept 255 - 32 /*Number of real (non-exception) interrupts*/
+.rept 256 - 32 /*Number of real (non-exception) interrupts*/
 .section .text.interruptHandlers, "ax"
 1:
 pushq $currentInterruptNumber


### PR DESCRIPTION
The IDT used to have an off-by-one error which was causing problems when a spurious interrupt occured. This was due to a missing handler in the generated IDT function pointers.

This fixes this.