### PR TITLE
Add tasks to least busy cpu

### DIFF
--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -125,6 +125,7 @@ extern "C" [[noreturn]] void kstart() {
       kout::print("Disabling legacy PIC\n");
       pic::disablePic();
     }
+    scheduler::init(madt->localApicCount());
     if (madt->localApicCount() > 1) {
       // Copy smp trampoline to low memory
       void *smpTrampolineDestination =
@@ -198,16 +199,16 @@ extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
 [[noreturn]] void kRun() {
   scheduler::setInitialTask(new task::ControlBlock());
   auto otherThreadFunction = [](void *) {
-    kout::print("Other thread got CPU time\n");
+    kout::printf("Other thread got CPU time on CPU %d\n", cpu::getCpuNumber());
     while (true) {
       scheduler::yield();
-      kout::print("Other thread got CPU time after yield\n");
+      kout::printf("Other thread got CPU time after yield on CPU %d\n", cpu::getCpuNumber());
     }
   };
   thread::create(otherThreadFunction, nullptr);
-  kout::print("Main thread yielding\n");
+  kout::printf("Main thread yielding on CPU %d\n", cpu::getCpuNumber());
   scheduler::yield();
-  kout::print("Main thread got CPU time after yield\n");
+  kout::printf("Main thread got CPU time after yield on CPU %d\n", cpu::getCpuNumber());
   scheduler::yield();
   // Just hault for now
   cpu::hault();

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -202,13 +202,15 @@ extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
     kout::printf("Other thread got CPU time on CPU %d\n", cpu::getCpuNumber());
     while (true) {
       scheduler::yield();
-      kout::printf("Other thread got CPU time after yield on CPU %d\n", cpu::getCpuNumber());
+      kout::printf("Other thread got CPU time after yield on CPU %d\n",
+                   cpu::getCpuNumber());
     }
   };
   thread::create(otherThreadFunction, nullptr);
   kout::printf("Main thread yielding on CPU %d\n", cpu::getCpuNumber());
   scheduler::yield();
-  kout::printf("Main thread got CPU time after yield on CPU %d\n", cpu::getCpuNumber());
+  kout::printf("Main thread got CPU time after yield on CPU %d\n",
+               cpu::getCpuNumber());
   scheduler::yield();
   // Just hault for now
   cpu::hault();

--- a/kernel/include/mykonos/scheduler.h
+++ b/kernel/include/mykonos/scheduler.h
@@ -21,10 +21,11 @@
 
 namespace scheduler {
 void addTask(task::ControlBlock *task);
-void tick();
 void yield();
 
+void init(unsigned numCpus);
 void setInitialTask(task::ControlBlock *task);
+void tick();
 } // namespace scheduler
 
 #endif

--- a/kernel/include/mykonos/task/taskQueue.h
+++ b/kernel/include/mykonos/task/taskQueue.h
@@ -52,7 +52,12 @@ public:
     lock.release();
     return result;
   }
-  unsigned getSize() { return size; }
+  unsigned getSize() {
+    lock.acquire();
+    unsigned result = size;
+    lock.release();
+    return result;
+  }
 
 private:
   lock::Spinlock lock;

--- a/kernel/include/mykonos/task/taskQueue.h
+++ b/kernel/include/mykonos/task/taskQueue.h
@@ -35,6 +35,7 @@ public:
       tail->next = value;
       tail = value;
     }
+    size++;
     lock.release();
   }
   ControlBlock *pop() {
@@ -46,15 +47,18 @@ public:
       } else {
         head = head->next;
       }
+      size--;
     }
     lock.release();
     return result;
   }
+  unsigned getSize() { return size; }
 
 private:
   lock::Spinlock lock;
   ControlBlock *head = nullptr;
   ControlBlock *tail = nullptr;
+  unsigned size;
 };
 } // namespace task
 

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -18,9 +18,9 @@
 #include <mykonos/kpanic.h>
 #include <mykonos/processors.h>
 #include <mykonos/scheduler.h>
+#include <mykonos/spinlock.h>
 #include <mykonos/task/controlBlock.h>
 #include <mykonos/task/taskQueue.h>
-#include <mykonos/spinlock.h>
 
 #define INITIAL_TIME_SLICE 5
 

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -60,12 +60,15 @@ public:
 };
 static Scheduler schedulers[MAX_CPUS];
 
+static unsigned cpuCount = 0;
+
 void addTask(task::ControlBlock *task) {
   schedulers[cpu::getCpuNumber()].addTask(task);
 }
 void tick() { schedulers[cpu::getCpuNumber()].tick(); }
 void yield() { schedulers[cpu::getCpuNumber()].yield(); }
 
+void init(unsigned numCpus) { cpuCount = numCpus; }
 void setInitialTask(task::ControlBlock *task) {
   schedulers[cpu::getCpuNumber()].setInitialTask(task);
 }

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -20,6 +20,7 @@
 #include <mykonos/scheduler.h>
 #include <mykonos/task/controlBlock.h>
 #include <mykonos/task/taskQueue.h>
+#include <mykonos/spinlock.h>
 
 #define INITIAL_TIME_SLICE 5
 
@@ -75,7 +76,7 @@ static Scheduler &getLeastBusy() {
   Scheduler *bestScheduler = &schedulers[0];
   unsigned bestTaskCount = bestScheduler->taskCount();
   for (unsigned i = 1; i < cpuCount; i++) {
-    if (schedulers[i].taskCount() > bestTaskCount) {
+    if (schedulers[i].taskCount() < bestTaskCount) {
       bestScheduler = &schedulers[i];
       bestTaskCount = bestScheduler->taskCount();
     }


### PR DESCRIPTION
This makes the addTask function add the task to the least busy CPU. This will be useful when tasks can exit and when each CPU does not create the same number of tasks for itself. However, in this case it is not as effective as just allocating each task to the current CPU. This is because every CPU checks which one is least busy in paralell and thus all get the same one. This will not be such an issue in future however as the different CPUs will not allocate tasks at the same time in this way.