### PR TITLE
made callbacks have to run processors::letCallerReturn() to allow the caller to return

### DIFF
--- a/kernel/arch/x86_64/include/mykonos/processors.h
+++ b/kernel/arch/x86_64/include/mykonos/processors.h
@@ -25,8 +25,10 @@
 
 namespace processors {
 // Run the specified callback on CPU cpuNumber. The function returns when the
-// callback returns
+// callback calls letCallerReturn()
 void runOn(unsigned cpuNumber, callback::Callback<bool> &&callback);
+
+void letCallerReturn();
 
 // Internal function. Called when the CPU receives a request to execute a
 // callback

--- a/kernel/arch/x86_64/kernel/processors/processors.cpp
+++ b/kernel/arch/x86_64/kernel/processors/processors.cpp
@@ -21,35 +21,46 @@
 #include <mykonos/cpu.h>
 
 namespace processors {
-callback::Callback<bool> *mailboxes[MAX_LOCAL_APICS];
+struct MailboxEntry {
+  callback::Callback<bool> *callback;
+  bool callerCanReturn;
+};
+static MailboxEntry mailboxes[MAX_CPUS];
 
 void runOn(unsigned cpuNumber, callback::Callback<bool> &&callback) {
-  if (cpuNumber < MAX_LOCAL_APICS) {
+  if (cpuNumber < MAX_CPUS) {
+    MailboxEntry &mailbox = mailboxes[cpuNumber];
     // Wait for all previous requests to complete
     while (true) {
-      while (mailboxes[cpuNumber] != nullptr) {
+      while (mailbox.callback != nullptr) {
         cpu::relax();
       }
-      if (__sync_bool_compare_and_swap(&mailboxes[cpuNumber], nullptr,
-                                       &callback)) {
+      if (__sync_bool_compare_and_swap(&mailbox.callback, nullptr, &callback)) {
         break;
       }
     }
+    mailbox.callerCanReturn = false;
     // Tell the CPU to start executing the request
     apic::localApic.sendIpi(PROCESSOR_CALLBACK_INTERRUPT, APIC_FIXED_IPI, false,
                             true, true, apic::localApicIds[cpuNumber]);
     // Wait for it to be handled
-    while (!mailboxes[cpuNumber]->hasRun()) {
+    while (!mailbox.callerCanReturn) {
       cpu::relax();
     }
     // Clean up
-    mailboxes[cpuNumber] = nullptr;
+    mailboxes[cpuNumber].callback = nullptr;
+  }
+}
+void letCallerReturn() {
+  MailboxEntry &mailbox = mailboxes[cpu::getCpuNumber()];
+  if (mailbox.callback != nullptr) {
+    mailbox.callerCanReturn = true;
   }
 }
 void receiveCall() {
   unsigned cpuNumber = cpu::getCpuNumber();
-  if (mailboxes[cpuNumber] != nullptr) {
-    (*mailboxes[cpuNumber])();
+  if (mailboxes[cpuNumber].callback != nullptr) {
+    (*mailboxes[cpuNumber].callback)();
   }
 }
 } // namespace processors

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -182,6 +182,7 @@ extern "C" [[noreturn]] void kstartApCpu(uint8_t cpuNumber) {
   auto otherCpuCode = [=]() -> bool {
     kout::printf("I am CPU %d called from CPU %d\n", cpu::getCpuNumber(),
                  cpuNumber);
+    processors::letCallerReturn();
     return true;
   };
   processors::runOn(

--- a/kernel/include/mykonos/callback.h
+++ b/kernel/include/mykonos/callback.h
@@ -21,16 +21,10 @@ namespace callback {
 // Note: Don't use with void return type.
 template <typename Result, typename... ParameterTypes> class Callback {
 private:
-  bool run = false;
   virtual Result invoke(ParameterTypes...);
 
 public:
-  Result operator()(ParameterTypes... args) {
-    Result res = invoke(args...);
-    run = true;
-    return res;
-  }
-  bool hasRun() { return run; }
+  Result operator()(ParameterTypes... args) { return invoke(args...); }
 };
 
 template <typename LambdaType, typename Result, typename... ParameterTypes>


### PR DESCRIPTION
This feature means that callbacks passed to processors::runOn have to call a function to allow the caller to return. Failing to do this will result in the caller hanging forever.

This feature will be useful when implementing cross-core preemption. In this case, the old model of returning from the callback makes the caller return is not a good idea. This is because the callback will only return when the thread interrupted by the preemption is resumed, which may never happen if the thread is terminated before getting more cpu time. This is a solution which allows for this case.