### PR TITLE
Create priorities for preemption

### DIFF
--- a/kernel/arch/x86_64/include/mykonos/thread.h
+++ b/kernel/arch/x86_64/include/mykonos/thread.h
@@ -20,7 +20,8 @@
 #include <mykonos/scheduler.h>
 
 namespace thread {
-void create(void (*entrypoint)(void *context), void *context, unsigned priority=PRIORITY_NORMAL);
+void create(void (*entrypoint)(void *context), void *context,
+            unsigned priority = PRIORITY_NORMAL);
 }
 
 #endif

--- a/kernel/arch/x86_64/include/mykonos/thread.h
+++ b/kernel/arch/x86_64/include/mykonos/thread.h
@@ -17,8 +17,10 @@
 #ifndef _MYKONOS_THREAD_H
 #define _MYKONOS_THREAD_H
 
+#include <mykonos/scheduler.h>
+
 namespace thread {
-void create(void (*entrypoint)(void *context), void *context);
+void create(void (*entrypoint)(void *context), void *context, unsigned priority=PRIORITY_NORMAL);
 }
 
 #endif

--- a/kernel/arch/x86_64/kernel/scheduler/threadCreator.cpp
+++ b/kernel/arch/x86_64/kernel/scheduler/threadCreator.cpp
@@ -21,8 +21,10 @@
 #include <mykonos/task/controlBlock.h>
 
 namespace thread {
-void create(void (*entrypoint)(void *context), void *context) {
+void create(void (*entrypoint)(void *context), void *context,
+            unsigned priority) {
   task::ControlBlock *task = new task::ControlBlock();
+  task->priority = priority;
   task->registers.rip = (void *)entrypoint;
   task->registers.rdi = (uint64_t)context;
   task->registers.rflags = 1 << 9; // Interrupt enable bit

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -218,7 +218,7 @@ static volatile unsigned numCpusWithInitialTasks = 0;
                    cpu::getCpuNumber());
     }
   };
-  thread::create(otherThreadFunction, nullptr);
+  thread::create(otherThreadFunction, nullptr, PRIORITY_HIGH);
   kout::printf("Main thread yielding on CPU %d\n", cpu::getCpuNumber());
   scheduler::yield();
   kout::printf("Main thread got CPU time after yield on CPU %d\n",

--- a/kernel/include/mykonos/memoryBlock.h
+++ b/kernel/include/mykonos/memoryBlock.h
@@ -57,7 +57,7 @@ private:
   void merge();
   void addBlock(Block block, bool acquireLock);
 
- public:
+public:
   void addBlock(Block block) { addBlock(block, true); }
   void *allocate(size_t amount);
   void returnMemory(void *ptr, size_t amount) {

--- a/kernel/include/mykonos/scheduler.h
+++ b/kernel/include/mykonos/scheduler.h
@@ -19,6 +19,12 @@
 
 #include <mykonos/task/controlBlock.h>
 
+#define PRIORITY_BACKGROUND 0
+#define PRIORITY_LOW 1
+#define PRIORITY_NORMAL 2
+#define PRIORITY_HIGH 3
+#define PRIORITY_HIGHEST 4
+
 namespace scheduler {
 void addTask(task::ControlBlock *task);
 void yield();

--- a/kernel/include/mykonos/task/taskQueue.h
+++ b/kernel/include/mykonos/task/taskQueue.h
@@ -38,6 +38,16 @@ public:
     size++;
     lock.release();
   }
+  void push_front(ControlBlock *value) {
+    lock.acquire();
+    if (head == nullptr) {
+      head = tail = value;
+    }else {
+      value->next = head;
+      head = value;
+    }
+    lock.release();
+  }
   ControlBlock *pop() {
     lock.acquire();
     ControlBlock *result = head;

--- a/kernel/include/mykonos/task/taskQueue.h
+++ b/kernel/include/mykonos/task/taskQueue.h
@@ -42,7 +42,7 @@ public:
     lock.acquire();
     if (head == nullptr) {
       head = tail = value;
-    }else {
+    } else {
       value->next = head;
       head = value;
     }

--- a/kernel/memory/memoryBlock.cpp
+++ b/kernel/memory/memoryBlock.cpp
@@ -98,8 +98,10 @@ void BlockMap::reserve(Block blockToRemove) {
         currentBlock.end = blockToRemove.start;
       } else { // blockToRemove is entirely inside currentBlock
         currentBlock = Block();
-        addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveStart), false);
-        addBlock(Block((void *)blockToRemoveEnd, (void *)currentBlockEnd), false);
+        addBlock(Block((void *)currentBlockStart, (void *)blockToRemoveStart),
+                 false);
+        addBlock(Block((void *)blockToRemoveEnd, (void *)currentBlockEnd),
+                 false);
       }
     }
   }

--- a/kernel/memory/memoryBlock_test.cpp
+++ b/kernel/memory/memoryBlock_test.cpp
@@ -53,7 +53,7 @@ bool blockMapTest(::test::Logger logger) {
     }
   }
   logger("blockMapTest: Passed stress tester\n");
-  map = BlockMap();
+  map.clear();
   // Reserve test
   map.reserve(Block((void *)0x1000, (void *)0x3000)); // Reserve the whole map
   if (map.allocate(1) != nullptr) {

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -35,9 +35,11 @@ private:
   unsigned cpuNumber;
   task::Queue tasks;
   task::ControlBlock *currentTask;
+  lock::Spinlock addTaskLock;
 
-public:
+ public:
   void addTask(task::ControlBlock *task) {
+    addTaskLock.acquire();
     if (currentTask->priority < task->priority) {
       tasks.push_front(task);
       if (cpuNumber == cpu::getCpuNumber()) {
@@ -54,6 +56,7 @@ public:
     } else {
       tasks.push(task);
     }
+    addTaskLock.release();
   }
   void tick() {
     if (--currentTask->timeSlice == 0) {


### PR DESCRIPTION
This adds task priorities for the scheduler to use for preemption. If a task's priority is higher than the new task's priority the scheduler will call yield on the relevent CPU immediately. This is very useful for things like interrupt handler threads which must be run immediately to be able to service devices in a reasonable amount of time.