### PR TITLE
Make the console faster

### DIFF
--- a/kernel/display/font/psfRenderer.cpp
+++ b/kernel/display/font/psfRenderer.cpp
@@ -43,21 +43,6 @@ void render(char c, unsigned x, unsigned y, display::Pixel foreground,
   uint8_t *glyph = fontFile.data + (c * fontFile.glyphSize);
   display::writeBitmap(x, y, fontFile.width, fontFile.height, glyph, foreground,
                        background);
-  /*for (unsigned glyphY = 0; glyphY < fontFile.height; glyphY++) {
-    for (unsigned glyphX = 0; glyphX < fontFile.width; glyphX++) {
-      uint8_t currentByte = glyph[glyphX / 8];
-      uint8_t currentBit = glyphX % 8;
-      unsigned displayX =
-          fontFile.width - glyphX + x; // We are currently going backwards
-      unsigned displayY = y + glyphY;
-      if ((currentByte & (1 << currentBit)) != 0) {
-        display::writePixel(displayX, displayY, foreground);
-      } else {
-        display::writePixel(displayX, displayY, background);
-      }
-    }
-    glyph += fontFile.glyphSize / fontFile.height;
-  }*/
 }
 unsigned getWidth() { return fontFile.width; }
 unsigned getHeight() { return fontFile.height; }

--- a/kernel/display/font/psfRenderer.cpp
+++ b/kernel/display/font/psfRenderer.cpp
@@ -41,7 +41,9 @@ namespace font {
 void render(char c, unsigned x, unsigned y, display::Pixel foreground,
             display::Pixel background) {
   uint8_t *glyph = fontFile.data + (c * fontFile.glyphSize);
-  for (unsigned glyphY = 0; glyphY < fontFile.height; glyphY++) {
+  display::writeBitmap(x, y, fontFile.width, fontFile.height, glyph, foreground,
+                       background);
+  /*for (unsigned glyphY = 0; glyphY < fontFile.height; glyphY++) {
     for (unsigned glyphX = 0; glyphX < fontFile.width; glyphX++) {
       uint8_t currentByte = glyph[glyphX / 8];
       uint8_t currentBit = glyphX % 8;
@@ -55,7 +57,7 @@ void render(char c, unsigned x, unsigned y, display::Pixel foreground,
       }
     }
     glyph += fontFile.glyphSize / fontFile.height;
-  }
+  }*/
 }
 unsigned getWidth() { return fontFile.width; }
 unsigned getHeight() { return fontFile.height; }

--- a/kernel/display/frameBuffer.cpp
+++ b/kernel/display/frameBuffer.cpp
@@ -46,9 +46,10 @@ void writeBitmap(unsigned initialX, unsigned initialY, unsigned width,
     height = getHeight() - initialY;
   }
   unsigned bytesPerPixel = frameBuffer.depth / 8;
+  uint8_t pixelBuffer[bytesPerPixel * width];
+  memset((void *)pixelBuffer, 0, sizeof(pixelBuffer));
   for (unsigned y = 0; y < height; y++) {
     uint8_t *bitmapLine = (uint8_t *)bitmap + y * bytesPerLine;
-    uint8_t pixelBuffer[bytesPerPixel * width] = {0};
     for (unsigned x = 0; x < width; x++) {
       uint8_t *pixelPointer = pixelBuffer + x * bytesPerPixel;
       uint8_t bitmapByte = bitmapLine[x / 8];

--- a/kernel/display/frameBuffer.cpp
+++ b/kernel/display/frameBuffer.cpp
@@ -35,6 +35,39 @@ void writePixel(unsigned x, unsigned y, Pixel pixel) {
     pixelPointer[0] = pixel.b;
   }
 }
+void writeBitmap(unsigned initialX, unsigned initialY, unsigned width,
+                 unsigned height, void *bitmap, Pixel foreground,
+                 Pixel background) {
+  unsigned bytesPerLine = (width + 7) / 8;
+  if (initialX + width > getWidth()) {
+    width = getWidth() - initialX;
+  }
+  if (initialY + height > getHeight()) {
+    height = getHeight() - initialY;
+  }
+  unsigned bytesPerPixel = frameBuffer.depth / 8;
+  for (unsigned y = 0; y < height; y++) {
+    uint8_t *bitmapLine = (uint8_t *)bitmap + y * bytesPerLine;
+    uint8_t pixelBuffer[bytesPerPixel * width] = {0};
+    for (unsigned x = 0; x < width; x++) {
+      uint8_t *pixelPointer = pixelBuffer + x * bytesPerPixel;
+      uint8_t bitmapByte = bitmapLine[x / 8];
+      if ((bitmapByte & (1 << (7 - x % 8))) == 0) {
+        pixelPointer[2] = background.r;
+        pixelPointer[1] = background.g;
+        pixelPointer[0] = background.b;
+      } else {
+        pixelPointer[2] = foreground.r;
+        pixelPointer[1] = foreground.g;
+        pixelPointer[0] = foreground.b;
+      }
+    }
+    uint8_t *displayLine =
+        frameBuffer.pointer +
+        ((y + initialY) * frameBuffer.pitch + initialX * bytesPerPixel);
+    memcpy((void *)displayLine, (void *)pixelBuffer, sizeof(pixelBuffer));
+  }
+}
 unsigned getWidth() { return frameBuffer.width; }
 unsigned getHeight() { return frameBuffer.height; }
 } // namespace display

--- a/kernel/include/mykonos/display.h
+++ b/kernel/include/mykonos/display.h
@@ -24,6 +24,8 @@ struct Pixel {
   uint8_t r, g, b;
 };
 void writePixel(unsigned x, unsigned y, Pixel pixel);
+void writeBitmap(unsigned x, unsigned y, unsigned width, unsigned height,
+                 void *bitmap, Pixel foreground, Pixel background);
 
 void writeCharacter(unsigned x, unsigned y, char c);
 


### PR DESCRIPTION
The display::writePixel interface is very slow. This is because it has to make several accesses for a single pixel.

This introduces a new interface for writing bitmaps directly which uses an optimized memcpy strategy to be able to copy multiple pixels at a time. This has made the console much faster to write to and scroll.