### PR TITLE
Made the load balancer better

### DIFF
--- a/kernel/include/mykonos/task/taskQueue.h
+++ b/kernel/include/mykonos/task/taskQueue.h
@@ -35,7 +35,7 @@ public:
       tail->next = value;
       tail = value;
     }
-    size++;
+    __atomic_fetch_add(&size, 1, __ATOMIC_SEQ_CST);
     lock.release();
   }
   void push_front(ControlBlock *value) {
@@ -46,6 +46,7 @@ public:
       value->next = head;
       head = value;
     }
+    __atomic_fetch_add(&size, 1, __ATOMIC_SEQ_CST);
     lock.release();
   }
   ControlBlock *pop() {
@@ -57,17 +58,12 @@ public:
       } else {
         head = head->next;
       }
-      size--;
+      __atomic_fetch_sub(&size, 1, __ATOMIC_SEQ_CST);
     }
     lock.release();
     return result;
   }
-  unsigned getSize() {
-    lock.acquire();
-    unsigned result = size;
-    lock.release();
-    return result;
-  }
+  unsigned getSize() { return __atomic_load_n(&size, __ATOMIC_SEQ_CST); }
 
 private:
   lock::Spinlock lock;

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -104,9 +104,12 @@ static Scheduler schedulers[MAX_CPUS];
 static unsigned cpuCount = 0;
 
 static Scheduler &getLeastBusy() {
-  Scheduler *bestScheduler = &schedulers[0];
+  Scheduler *bestScheduler = &schedulers[cpu::getCpuNumber()];
   unsigned bestTaskCount = bestScheduler->taskCount();
-  for (unsigned i = 1; i < cpuCount; i++) {
+  for (unsigned i = 0; i < cpuCount; i++) {
+    if (bestTaskCount == 0) {
+      break;
+    }
     if (schedulers[i].taskCount() < bestTaskCount) {
       bestScheduler = &schedulers[i];
       bestTaskCount = bestScheduler->taskCount();


### PR DESCRIPTION
The load balancer used to prefer allocating new tasks to CPU 0. This meant that in situations where multiple CPUs are allocating tasks at the same time the tasks would all end up on CPU 0.

The load balancer now prefers the current CPU which makes it harder for tasks to pile up due to multiple CPUs. It also decreases the number of IPIs sent for preemption.