### PR TITLE
Allow thread destruction

### DIFF
--- a/kernel/arch/x86_64/Make.steps
+++ b/kernel/arch/x86_64/Make.steps
@@ -7,4 +7,5 @@ STEPS+=arch/x86_64/kernel/exceptions/exceptionHandlers.o
 STEPS+=arch/x86_64/kernel/apic/apic.o arch/x86_64/kernel/apic/apicTimer.o
 STEPS+=arch/x86_64/kernel/smp/smp.o
 STEPS+=arch/x86_64/kernel/processors/processors.o
-STEPS+=arch/x86_64/kernel/scheduler/registers.o arch/x86_64/kernel/scheduler/threadCreator.o
+STEPS+=arch/x86_64/kernel/scheduler/registers.o arch/x86_64/kernel/scheduler/threadCreator.o arch/x86_64/kernel/scheduler/threadDestroyer.o
+STEPS+=arch/x86_64/kernel/stacks/stackSwitcher.o

--- a/kernel/arch/x86_64/include/mykonos/stacks.h
+++ b/kernel/arch/x86_64/include/mykonos/stacks.h
@@ -29,14 +29,14 @@ static inline void *allocateStack() {
 }
 // stackPointer is a pointer returned by allocateStack().
 static inline void freeStack(void *stackPointer) {
-  memory::freeMemory((void *)((uint8_t *)stackPointer + DEFAULT_STACK_SIZE),
+  memory::freeMemory((void *)((uint8_t *)stackPointer - DEFAULT_STACK_SIZE),
                      DEFAULT_STACK_SIZE);
 }
 
 // Run the callback on another stack. Will never return.
 extern "C" [[noreturn]] void switchStack(void *newStack,
-                              [[noreturn]] void (*callback)(void *),
-                              void *context);
-}  // namespace stacks
+                                         [[noreturn]] void (*callback)(void *),
+                                         void *context);
+} // namespace stacks
 
 #endif

--- a/kernel/arch/x86_64/include/mykonos/stacks.h
+++ b/kernel/arch/x86_64/include/mykonos/stacks.h
@@ -32,6 +32,11 @@ static inline void freeStack(void *stackPointer) {
   memory::freeMemory((void *)((uint8_t *)stackPointer + DEFAULT_STACK_SIZE),
                      DEFAULT_STACK_SIZE);
 }
-} // namespace stacks
+
+// Run the callback on another stack. Will never return.
+extern "C" [[noreturn]] void switchStack(void *newStack,
+                              [[noreturn]] void (*callback)(void *),
+                              void *context);
+}  // namespace stacks
 
 #endif

--- a/kernel/arch/x86_64/include/mykonos/stacks.h
+++ b/kernel/arch/x86_64/include/mykonos/stacks.h
@@ -22,9 +22,15 @@
 #define DEFAULT_STACK_SIZE 16384
 
 namespace stacks {
+// Call freeStack() to free the stack. Do not use kfree!
 static inline void *allocateStack() {
   return (void *)((uint8_t *)memory::allocateMemory(DEFAULT_STACK_SIZE) +
                   DEFAULT_STACK_SIZE);
+}
+// stackPointer is a pointer returned by allocateStack().
+static inline void freeStack(void *stackPointer) {
+  memory::freeMemory((void *)((uint8_t *)stackPointer + DEFAULT_STACK_SIZE),
+                     DEFAULT_STACK_SIZE);
 }
 } // namespace stacks
 

--- a/kernel/arch/x86_64/kernel/scheduler/registers.S
+++ b/kernel/arch/x86_64/kernel/scheduler/registers.S
@@ -37,12 +37,14 @@
 .text
 .globl swapRegisters
 swapRegisters:
-/*Save*/
+/*Save old registers*/
+
 /*get rip and rflags*/
 popq RIP_OFFSET(%rdi)
 pushfq
 popq RFLAGS_OFFSET(%rdi)
 
+/*Save the GPRs*/
 movq %rax, RAX_OFFSET(%rdi)
 movq %rcx, RCX_OFFSET(%rdi)
 movq %rdx, RDX_OFFSET(%rdi)
@@ -59,34 +61,40 @@ movq %r12, R12_OFFSET(%rdi)
 movq %r13, R13_OFFSET(%rdi)
 movq %r14, R14_OFFSET(%rdi)
 movq %r15, R15_OFFSET(%rdi)
+/*Save cr3*/
 movq %cr3, %rax
 movq %rax, CR3_OFFSET(%rdi)
-/*Load*/
-movq CR3_OFFSET(%rsi), %rdx
+/*Load new registers*/
+movq %rsi, %rdi
+jmp restoreRegisters
+
+.globl restoreRegisters
+restoreRegisters:
+movq CR3_OFFSET(%rdi), %rdx
 cmp %rax, %rdx
 je 1f
 movq %rdx, %cr3
 1:
-movq RAX_OFFSET(%rsi), %rax
-movq RCX_OFFSET(%rsi), %rcx
-movq RDX_OFFSET(%rsi), %rdx
-movq RBX_OFFSET(%rsi), %rbx
-movq RSP_OFFSET(%rsi), %rsp
-movq RBP_OFFSET(%rsi), %rbp
-/*Don't movq RSI_OFFSET(%rsi), %rsi to not lose our pointer*/
-movq RDI_OFFSET(%rsi), %rdi
-movq R8_OFFSET(%rsi), %r8
-movq R9_OFFSET(%rsi), %r9
-movq R10_OFFSET(%rsi), %r10
-movq R11_OFFSET(%rsi), %r11
-movq R12_OFFSET(%rsi), %r12
-movq R13_OFFSET(%rsi), %r13
-movq R14_OFFSET(%rsi), %r14
-movq R15_OFFSET(%rsi), %r15
+movq RAX_OFFSET(%rdi), %rax
+movq RCX_OFFSET(%rdi), %rcx
+movq RDX_OFFSET(%rdi), %rdx
+movq RBX_OFFSET(%rdi), %rbx
+movq RSP_OFFSET(%rdi), %rsp
+movq RBP_OFFSET(%rdi), %rbp
+movq RSI_OFFSET(%rdi), %rsi
+/*Don't movq RDI_OFFSET(%rdi), %rdi to not lose our pointer*/
+movq R8_OFFSET(%rdi), %r8
+movq R9_OFFSET(%rdi), %r9
+movq R10_OFFSET(%rdi), %r10
+movq R11_OFFSET(%rdi), %r11
+movq R12_OFFSET(%rdi), %r12
+movq R13_OFFSET(%rdi), %r13
+movq R14_OFFSET(%rdi), %r14
+movq R15_OFFSET(%rdi), %r15
 /*Get rip and rflags*/
-pushq RIP_OFFSET(%rsi)
-pushq RFLAGS_OFFSET(%rsi)
-/*Reload %rsi and return*/
-movq RSI_OFFSET(%rsi), %rsi
+pushq RIP_OFFSET(%rdi)
+pushq RFLAGS_OFFSET(%rdi)
+/*Reload %rdi and return*/
+movq RDI_OFFSET(%rdi), %rdi
 popfq
 retq

--- a/kernel/arch/x86_64/kernel/scheduler/threadCreator.cpp
+++ b/kernel/arch/x86_64/kernel/scheduler/threadCreator.cpp
@@ -23,12 +23,14 @@
 namespace thread {
 void create(void (*entrypoint)(void *context), void *context,
             unsigned priority) {
+  void *stack = stacks::allocateStack();
   task::ControlBlock *task = new task::ControlBlock();
+  task->originalStackPointer = stack;
   task->priority = priority;
   task->registers.rip = (void *)entrypoint;
   task->registers.rdi = (uint64_t)context;
   task->registers.rflags = 1 << 9; // Interrupt enable bit
-  task->registers.rsp = (uint64_t)stacks::allocateStack();
+  task->registers.rsp = (uint64_t)stack;
   void *cr3;
   __asm__("movq %%cr3, %0" : "=r"(cr3));
   task->registers.cr3 = cr3;

--- a/kernel/arch/x86_64/kernel/scheduler/threadDestroyer.cpp
+++ b/kernel/arch/x86_64/kernel/scheduler/threadDestroyer.cpp
@@ -1,0 +1,41 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/cpu.h>
+#include <mykonos/processors.h>
+#include <mykonos/scheduler.h>
+#include <mykonos/stacks.h>
+#include <mykonos/thread.h>
+
+namespace thread {
+static void *emergencyStacks[MAX_CPUS];
+[[noreturn]] void destroy() {
+  cpu::disableLocalIrqs();
+  auto currentTask = scheduler::block();
+  unsigned cpuNumber = cpu::getCpuNumber();
+  if (emergencyStacks[cpuNumber] == nullptr) {
+    emergencyStacks[cpuNumber] = stacks::allocateStack();
+  }
+  auto destructionCode = [](void *currentTaskPointer) {
+    task::ControlBlock *currentTask = (task::ControlBlock *)currentTaskPointer;
+    stacks::freeStack(currentTask->originalStackPointer);
+    delete currentTask;
+    scheduler::yield();
+  };
+  stacks::switchStack(emergencyStacks[cpuNumber], destructionCode,
+                      (void *)currentTask);
+}
+} // namespace thread

--- a/kernel/arch/x86_64/kernel/stacks/stackSwitcher.S
+++ b/kernel/arch/x86_64/kernel/stacks/stackSwitcher.S
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022  Jett Thompson
+    Copyright (C) 2022 Jett Thompson
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,15 +14,11 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#ifndef _MYKONOS_THREAD_H
-#define _MYKONOS_THREAD_H
 
-#include <mykonos/scheduler.h>
-
-namespace thread {
-void create(void (*entrypoint)(void *context), void *context,
-            unsigned priority = PRIORITY_NORMAL);
-[[noreturn]] void destroy();
-} // namespace thread
-
-#endif
+.text
+.globl switchStack
+switchStack:
+xorq %rbp, %rbp
+movq %rdi, %rsp
+movq %rdx, %rdi
+jmp *%rsi

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -213,11 +213,10 @@ static volatile unsigned numCpusDone = 0;
   }
   auto otherThreadFunction = [](void *) {
     kout::printf("Other thread got CPU time on CPU %d\n", cpu::getCpuNumber());
-    while (true) {
-      scheduler::yield();
-      kout::printf("Other thread got CPU time after yield on CPU %d\n",
-                   cpu::getCpuNumber());
-    }
+    scheduler::yield();
+    kout::printf("Other thread got CPU time after yield on CPU %d\n",
+                 cpu::getCpuNumber());
+    thread::destroy();
   };
   thread::create(otherThreadFunction, nullptr, PRIORITY_HIGH);
   kout::printf("Main thread yielding on CPU %d\n", cpu::getCpuNumber());

--- a/kernel/include/mykonos/scheduler.h
+++ b/kernel/include/mykonos/scheduler.h
@@ -29,6 +29,11 @@ namespace scheduler {
 // You should release any spinlocks first.
 void yield();
 
+task::ControlBlock *currentTask();
+
+// Returns the current task and removes it from the scheduler. Don't lose it!
+task::ControlBlock *block();
+
 // You usually don't want to do this. Consider thread::create instead.
 void addTask(task::ControlBlock *task);
 

--- a/kernel/include/mykonos/task/controlBlock.h
+++ b/kernel/include/mykonos/task/controlBlock.h
@@ -22,9 +22,10 @@
 namespace task {
 struct ControlBlock {
   Registers registers;
+  void *originalStackPointer = nullptr;
   unsigned timeSlice;
   unsigned priority;
-  ControlBlock *next;
+  ControlBlock *next = nullptr;
 };
 } // namespace task
 

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -25,9 +25,11 @@
 #define INITIAL_TIME_SLICE 5
 
 extern "C" {
-// Assembly function
-// Save current registers into *from and load the ones in *to into the CPU
+// Assembly functions
+// Save current registers into *from and load the ones in *to into the CPU.
 void swapRegisters(task::Registers *from, task::Registers *to);
+// Just load *regs into the CPU.
+void restoreRegisters(task::Registers *regs);
 }
 
 namespace scheduler {
@@ -41,7 +43,7 @@ private:
 public:
   void addTask(task::ControlBlock *task) {
     addTaskLock.acquire();
-    if (currentTask->priority < task->priority) {
+    if (currentTask == nullptr || currentTask->priority < task->priority) {
       tasks.push_front(task);
       if (cpuNumber == cpu::getCpuNumber()) {
         addTaskLock.release();
@@ -62,7 +64,7 @@ public:
     }
   }
   void tick() {
-    if (--currentTask->timeSlice == 0) {
+    if (currentTask != nullptr && --currentTask->timeSlice == 0) {
       yield();
     }
   }
@@ -72,10 +74,14 @@ public:
     task::ControlBlock *from = currentTask;
     task::ControlBlock *to = tasks.pop();
     if (to != nullptr) {
-      tasks.push(from);
       to->timeSlice = INITIAL_TIME_SLICE;
       currentTask = to;
-      swapRegisters(&from->registers, &to->registers);
+      if (from != nullptr) {
+        tasks.push(from);
+        swapRegisters(&from->registers, &to->registers);
+      } else {
+        restoreRegisters(&to->registers);
+      }
     }
     if (enableLocalIrqs) {
       cpu::enableLocalIrqs();


### PR DESCRIPTION
This allows threads to be destroyed. It also creates a function block() which can be used to implement other synchronization primitives such as mutexes.