### PR TITLE
Enabled time slicing

### DIFF
--- a/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.cpp
+++ b/kernel/arch/x86_64/kernel/interrupts/interruptHandlers.cpp
@@ -15,12 +15,19 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <mykonos/apic.h>
+#include <mykonos/apicTimer.h>
 #include <mykonos/processors.h>
+#include <mykonos/scheduler.h>
 
 #include <stdint.h>
 
 extern "C" void handleInterrupt(uint8_t interruptNumber) {
   switch (interruptNumber) {
+  case APIC_TIMER_INTERRUPT: {
+    apic::localApic.eoi();
+    scheduler::tick();
+    break;
+  }
   case PROCESSOR_CALLBACK_INTERRUPT: {
     apic::localApic.eoi();
     processors::receiveCall();


### PR DESCRIPTION
All of the pieces for time slicing have been implemented a while ago. The APIC timer was set up a while ago and the scheduler::tick function has been around since the scheduler itself. This just calls scheduler::tick from inside the APIC timer interrupt handler and makes startup.cpp stop using yield to run the other thread.