### PR TITLE
added a lock which prevents a task from being run multiple times at once

### DIFF
--- a/kernel/arch/x86_64/kernel/scheduler/registers.S
+++ b/kernel/arch/x86_64/kernel/scheduler/registers.S
@@ -38,7 +38,6 @@
 .globl swapRegisters
 swapRegisters:
 /*Save old registers*/
-
 /*get rip and rflags*/
 popq RIP_OFFSET(%rdi)
 pushfq
@@ -64,12 +63,22 @@ movq %r15, R15_OFFSET(%rdi)
 /*Save cr3*/
 movq %cr3, %rax
 movq %rax, CR3_OFFSET(%rdi)
+/*Unlock the task*/
+/*Save to into %rbx*/
+movq %rsi, %rbx
+/*%rdi already contains the old task*/
+call unlockTask
 /*Load new registers*/
-movq %rsi, %rdi
+movq %rbx, %rdi
 jmp restoreRegisters
 
 .globl restoreRegisters
 restoreRegisters:
+/*Lock the task*/
+movq %rdi, %rbx
+call lockTask
+movq %rbx, %rdi
+
 movq CR3_OFFSET(%rdi), %rdx
 cmp %rax, %rdx
 je 1f

--- a/kernel/include/mykonos/task/controlBlock.h
+++ b/kernel/include/mykonos/task/controlBlock.h
@@ -17,6 +17,7 @@
 #ifndef _MYKONOS_TASK_CONTROL_BLOCK_H
 #define _MYKONOS_TASK_CONTROL_BLOCK_H
 
+#include <mykonos/spinlock.h>
 #include <mykonos/task/registers.h>
 
 namespace task {
@@ -25,6 +26,7 @@ enum class State { RUNNING, RUNNABLE, BLOCKING };
 struct ControlBlock {
   Registers registers;
   void *originalStackPointer = nullptr;
+  lock::Spinlock runLock;
   State state;
   unsigned timeSlice;
   unsigned priority;


### PR DESCRIPTION
This will be useful for preventing several race conditions in synchronization primitives such as mutexes which use a task queue to be woken up. If the wake up condition happens before the task finishes saving its state it will not be run again from the last save point. This is a very important feature.