### PR TITLE
Remove monitor instructions

### DIFF
--- a/debug/qemu.gdb
+++ b/debug/qemu.gdb
@@ -1,2 +1,2 @@
 file build/mykonos.debug
-target remote | qemu-system-x86_64 -machine q35 -cpu qemu64,rdtscp,monitor -S -gdb stdio -cdrom build/mykonos.iso
+target remote | qemu-system-x86_64 -machine q35 -cpu qemu64,rdtscp,monitor -S -gdb stdio -cdrom build/mykonos.iso -no-reboot -no-shutdown -smp 4

--- a/kernel/arch/x86_64/include/mykonos/cpu.h
+++ b/kernel/arch/x86_64/include/mykonos/cpu.h
@@ -79,24 +79,6 @@ static inline void mfence() { __asm__ volatile("mfence" : : : "memory"); }
 // Pause instruction
 static inline void relax() { __asm__ volatile("pause"); }
 
-static inline void monitor(void *address) {
-  __asm__("monitor" : : "a"(address), "c"(0), "d"(0) : "memory");
-}
-static inline void mwait(unsigned cState) {
-  unsigned eax = ((cState - 1) & 0xf) << 4;
-  __asm__("mwait" : : "a"(eax), "c"(0) : "memory");
-}
-
-template <typename T>
-static inline void waitForChanges(volatile T *ptr, T oldValue) {
-  while (*ptr == oldValue) {
-    monitor((void *)ptr);
-    if (*ptr == oldValue) {
-      mwait(1);
-    }
-  }
-}
-
 // Hault forever ignoring IRQs
 [[noreturn]] static inline void hault() {
   disableLocalIrqs();

--- a/kernel/arch/x86_64/kernel/cpuidCheck.cpp
+++ b/kernel/arch/x86_64/kernel/cpuidCheck.cpp
@@ -19,8 +19,6 @@
 #include <cpuid.h>
 #include <mykonos/kout.h>
 
-#define CPUID_0000_0001_ECX_MONITOR (1 << 3)
-
 #define CPUID_8000_0001_EDX_RDTSCP (1 << 27)
 
 namespace cpuid {
@@ -28,10 +26,6 @@ bool checkCpuidFlags() {
   unsigned eax = 0, ebx = 0, ecx = 0, edx = 0;
   // Standard features (fn0x0000_0001)
   __get_cpuid(0x00000001, &eax, &ebx, &ecx, &edx);
-  if ((ecx & CPUID_0000_0001_ECX_MONITOR) == 0) {
-    kout::print("Your CPU does not support monitor/mwait\n");
-    return false;
-  }
   // Extended features (fn0x8000_0001)
   __get_cpuid(0x80000001, &eax, &ebx, &ecx, &edx);
   if ((edx & CPUID_8000_0001_EDX_RDTSCP) == 0) {


### PR DESCRIPTION
Removes the requirement of the CPU to support the monitor and mwait instructions. These are no longer used so it should be fine to remove them.