### PR TITLE
Initialize scheduler earlier

### DIFF
--- a/kernel/include/mykonos/scheduler.h
+++ b/kernel/include/mykonos/scheduler.h
@@ -48,10 +48,8 @@ void addTask(task::ControlBlock *task);
 [[noreturn]] void switchToSchedulerStack(void (*callback)(void *),
                                          void *context);
 
-// Call on startup to initialize the scheduler
-void init(unsigned numCpus);
-// Call on each CPU with a freshly allocated task::ControlBlock
-void setInitialTask(task::ControlBlock *task);
+// Call for each CPU with a freshly allocated task::ControlBlock
+void init(unsigned cpuNumber, task::ControlBlock *task);
 // Call every 10ms for time slicing
 void tick();
 } // namespace scheduler

--- a/kernel/scheduler/scheduler.cpp
+++ b/kernel/scheduler/scheduler.cpp
@@ -169,20 +169,11 @@ public:
     }
   }
 
-  void setInitialTask(task::ControlBlock *task) {
-    if (currentTask == nullptr) {
-      bool enableLocalIrqs = cpu::localIrqState();
-      task->runLock.acquire();
-      if (enableLocalIrqs) {
-        cpu::enableLocalIrqs();
-      }
-      currentTask = task;
-    } else {
-      kpanic("Cannot set initial task twice");
-    }
+  void init(unsigned cpuNumber, task::ControlBlock *task) {
+    this->cpuNumber = cpuNumber;
+    task->runLock.acquire();
+    currentTask = task;
   }
-
-  void setCpuNumber(unsigned cpuNumber) { this->cpuNumber = cpuNumber; }
 };
 static Scheduler schedulers[MAX_CPUS];
 
@@ -220,13 +211,8 @@ task::ControlBlock *block() { return schedulers[cpu::getCpuNumber()].block(); }
 void lock() { schedulers[cpu::getCpuNumber()].lock(); }
 void unlock() { schedulers[cpu::getCpuNumber()].unlock(); }
 
-void init(unsigned numCpus) {
-  cpuCount = numCpus;
-  for (unsigned i = 0; i < numCpus; i++) {
-    schedulers[i].setCpuNumber(i);
-  }
-}
-void setInitialTask(task::ControlBlock *task) {
-  schedulers[cpu::getCpuNumber()].setInitialTask(task);
+void init(unsigned cpuNumber, task::ControlBlock *task) {
+  schedulers[cpuNumber].init(cpuNumber, task);
+  cpuCount++;
 }
 } // namespace scheduler


### PR DESCRIPTION
The scheduler used to be initialized after the rest of the per-CPU initialization was complete. This means that it is not possible to use any of the scheduler features such as blocking until each CPU has finished its initialization.

Now the BSP initializes the scheduler for each CPU before starting it which allows for these features to possibly be used before kRun.