### PR TITLE
Tlb shootdown

### DIFF
--- a/kernel/arch/x86_64/include/mykonos/paging.h
+++ b/kernel/arch/x86_64/include/mykonos/paging.h
@@ -22,7 +22,12 @@
 namespace paging {
 void mapPage(void *virtualAddress, void *physicalAddress, PageTableFlags flags,
              bool allocated, bool cacheable);
+// Unmaps the page and invalidates the TLB for the page
 void unmapPage(void *virtualAddress);
+
+static inline void invalidateTlb(void *address) {
+  __asm__ volatile("invlpg (%0)" : : "r"(address) : "memory");
+}
 } // namespace paging
 
 #endif

--- a/kernel/arch/x86_64/kernel/paging/paging.cpp
+++ b/kernel/arch/x86_64/kernel/paging/paging.cpp
@@ -97,9 +97,6 @@ void mapPage(void *virtualAddress, void *physicalAddress, PageTableFlags flags,
       (PageTableEntry)((uint64_t)flags | ((uint64_t)physicalAddress & ~4095ul));
   *getPageTableEntry(virtualAddress, true) = pageTableEntry;
 }
-static void invalidateTlbCache(void *address) {
-  __asm__ volatile("invlpg (%0)" : : "r"(address) : "memory");
-}
 void unmapPage(void *virtualAddress) {
   PageTableEntry *pageTableEntry = getPageTableEntry(virtualAddress, false);
   if (pageTableEntry != nullptr) {
@@ -108,7 +105,7 @@ void unmapPage(void *virtualAddress) {
                           ((1ul << 52) - 1));
     }
     *pageTableEntry = (PageTableEntry)0;
-    invalidateTlbCache(virtualAddress);
+    invalidateTlb(virtualAddress);
   }
 }
 } // namespace paging


### PR DESCRIPTION
Makes the kernel perform TLB shootdowns. The kfree function interrupts each CPU and makes it invalidate the entry in the TLB. This will make sure reuse of virtual addresses will not cause TLB issues on SMP systems.