### PR TITLE
Parse mcfg table

### DIFF
--- a/kernel/acpi/Make.steps
+++ b/kernel/acpi/Make.steps
@@ -1,1 +1,1 @@
-STEPS+=acpi/tables.o acpi/rsdt.o acpi/madt.o acpi/hpet.o
+STEPS+=acpi/tables.o acpi/rsdt.o acpi/madt.o acpi/hpet.o acpi/mcfg.o

--- a/kernel/acpi/mcfg.cpp
+++ b/kernel/acpi/mcfg.cpp
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/acpi/mcfg.h>
+
+#include <mykonos/kmalloc.h>
+#include <mykonos/kout.h>
+
+namespace acpi {
+McfgTableManager::McfgTableManager(TableHeader *header)
+    : TableManager(TableType::MCFG) {
+  this->numEntries = (header->length - 44) / 16;
+  McfgTableEntry *tableEntries = (McfgTableEntry *)((size_t)header + 44);
+  for (unsigned i = 0; i < numEntries; i++) {
+    kout::printf("Base address: %p\n", tableEntries->address);
+  }
+  memory::unmapMemory(header, header->length);
+}
+} // namespace acpi

--- a/kernel/acpi/mcfg.cpp
+++ b/kernel/acpi/mcfg.cpp
@@ -33,6 +33,7 @@ McfgTableManager::McfgTableManager(TableHeader *header)
     entries[i] = {mappedAddress, tableEntry.segmentGroup,
                   tableEntry.firstBusNumber, tableEntry.lastBusNumber};
   }
+  kout::printf("Found %d MCFG entries\n", numEntries);
   memory::unmapMemory(header, header->length);
 }
 } // namespace acpi

--- a/kernel/acpi/mcfg.cpp
+++ b/kernel/acpi/mcfg.cpp
@@ -25,7 +25,13 @@ McfgTableManager::McfgTableManager(TableHeader *header)
   this->numEntries = (header->length - 44) / 16;
   McfgTableEntry *tableEntries = (McfgTableEntry *)((size_t)header + 44);
   for (unsigned i = 0; i < numEntries; i++) {
-    kout::printf("Base address: %p\n", tableEntries->address);
+    auto &tableEntry = tableEntries[i];
+    void *mappedAddress = memory::mapAddress(
+        (void *)tableEntry.address,
+        (tableEntry.lastBusNumber - tableEntry.firstBusNumber) * 8192 * 4096,
+        false);
+    entries[i] = {mappedAddress, tableEntry.segmentGroup,
+                  tableEntry.firstBusNumber, tableEntry.lastBusNumber};
   }
   memory::unmapMemory(header, header->length);
 }

--- a/kernel/acpi/tables.cpp
+++ b/kernel/acpi/tables.cpp
@@ -19,6 +19,7 @@
 
 #include <mykonos/acpi/hpet.h>
 #include <mykonos/acpi/madt.h>
+#include <mykonos/acpi/mcfg.h>
 #include <mykonos/acpi/rsdt.h>
 
 #include <mykonos/kmalloc.h>
@@ -42,11 +43,15 @@ TableManager *loadMadt(TableHeader *header) {
 TableManager *loadHpet(TableHeader *header) {
   return new HpetTableManager(header);
 }
+TableManager *loadMcfg(TableHeader *header) {
+  return new McfgTableManager(header);
+}
 
 static TableHandler tableHandlers[] = {{"RSDT", loadRsdt},
                                        {"XSDT", loadRsdt},
                                        {"APIC", loadMadt},
-                                       {"HPET", loadHpet}};
+                                       {"HPET", loadHpet},
+                                       {"MCFG", loadMcfg}};
 #define numTableHandlers (sizeof(tableHandlers) / sizeof(TableHandler))
 
 static bool doChecksum(TableHeader *header) {

--- a/kernel/include/mykonos/acpi/mcfg.h
+++ b/kernel/include/mykonos/acpi/mcfg.h
@@ -24,7 +24,7 @@
 
 namespace acpi {
 struct McfgEntry {
-  void *startAddress;
+  void *address;
   unsigned segmentGroup;
   unsigned firstBusNumber;
   unsigned lastBusNumber;

--- a/kernel/include/mykonos/acpi/mcfg.h
+++ b/kernel/include/mykonos/acpi/mcfg.h
@@ -1,0 +1,57 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_ACPI_MCFG_H
+#define _MYKONOS_ACPI_MCFG_H
+
+#include <mykonos/acpi/tables.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace acpi {
+struct McfgEntry {
+  void *startAddress;
+  unsigned segmentGroup;
+  unsigned firstBusNumber;
+  unsigned lastBusNumber;
+};
+#define MAX_MCFG_ENTRIES 16
+class McfgTableManager : public TableManager {
+public:
+  McfgTableManager(TableHeader *header);
+
+  unsigned entryCount() { return numEntries; }
+  McfgEntry getEntry(unsigned index) {
+    return index < numEntries ? entries[index] : McfgEntry{nullptr, 0, 0, 0};
+  }
+
+private:
+  unsigned numEntries;
+  McfgEntry entries[MAX_MCFG_ENTRIES];
+};
+
+struct McfgTableEntry {
+  uint64_t address;
+  uint16_t segmentGroup;
+  uint8_t firstBusNumber;
+  uint8_t lastBusNumber;
+  uint32_t reserved;
+};
+static_assert(sizeof(McfgTableEntry) == 16, "McfgTableEntry must be 16 bytes");
+} // namespace acpi
+
+#endif

--- a/kernel/include/mykonos/acpi/tables.h
+++ b/kernel/include/mykonos/acpi/tables.h
@@ -41,7 +41,7 @@ struct __attribute__((packed)) Address {
 };
 static_assert(sizeof(Address) == 12, "Address is not packed");
 
-enum class TableType { RSDT, MADT, HPET };
+enum class TableType { RSDT, MADT, HPET, MCFG };
 class TableManager {
 public:
   const TableType type;


### PR DESCRIPTION
The MCFG tables are used to describe where the PCIE MMIO is located.