### PR TITLE
Create device tree

### DIFF
--- a/kernel/drivers/Make.steps
+++ b/kernel/drivers/Make.steps
@@ -1,1 +1,2 @@
+STEPS+=drivers/tree.o
 STEPS+=drivers/hpet/hpet.o

--- a/kernel/drivers/tree.cpp
+++ b/kernel/drivers/tree.cpp
@@ -1,0 +1,31 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/drivers/tree.h>
+#include <mykonos/thread.h>
+
+namespace drivers {
+void DeviceTree::appendAndLoad(DeviceTree *child) {
+  lastChild->next = child;
+  lastChild = child;
+  thread::create(
+      [](void *childPointer) {
+        ((DeviceTree *)childPointer)->load();
+        thread::destroy();
+      },
+      (void *)child);
+}
+} // namespace drivers

--- a/kernel/drivers/tree.cpp
+++ b/kernel/drivers/tree.cpp
@@ -19,8 +19,12 @@
 
 namespace drivers {
 void DeviceTree::appendAndLoad(DeviceTree *child) {
-  lastChild->next = child;
-  lastChild = child;
+  if (firstChild == nullptr) {
+    firstChild = lastChild = child;
+  } else {
+    lastChild->next = child;
+    lastChild = child;
+  }
   thread::create(
       [](void *childPointer) {
         ((DeviceTree *)childPointer)->load();

--- a/kernel/include/mykonos/drivers/tree.h
+++ b/kernel/include/mykonos/drivers/tree.h
@@ -1,0 +1,71 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_DRIVERS_TREE_H
+#define _MYKONOS_DRIVERS_TREE_H
+
+namespace drivers {
+enum class DeviceType { ACPI };
+
+class DeviceTree {
+public:
+  class Iterator {
+  private:
+    DeviceTree *ptr;
+
+  public:
+    Iterator(DeviceTree *tree) : ptr(tree) {}
+
+    Iterator operator++(int) {
+      Iterator result = *this;
+      ptr = ptr->next;
+      return result;
+    }
+    Iterator operator++() {
+      ptr = ptr->next;
+      return *this;
+    }
+
+    DeviceTree &operator*() { return *ptr; }
+
+    bool operator==(Iterator &other) { return this->ptr == other.ptr; }
+    bool operator!=(Iterator &other) { return !(*this == other); }
+
+    operator bool() { return ptr != nullptr; }
+  };
+
+  DeviceTree(DeviceType type) : type(type) {}
+  virtual ~DeviceTree() {}
+
+  DeviceType getType() { return type; }
+
+  Iterator begin() { return Iterator(firstChild); }
+  Iterator end() { return Iterator(nullptr); }
+
+protected:
+  void appendChild(DeviceTree *child);
+
+private:
+  const DeviceType type;
+
+  DeviceTree *firstChild = nullptr;
+  DeviceTree *lastChild = nullptr;
+
+  DeviceTree *next = nullptr;
+};
+} // namespace drivers
+
+#endif

--- a/kernel/include/mykonos/drivers/tree.h
+++ b/kernel/include/mykonos/drivers/tree.h
@@ -56,7 +56,9 @@ public:
   Iterator end() { return Iterator(nullptr); }
 
 protected:
-  void appendChild(DeviceTree *child);
+  void appendAndLoad(DeviceTree *child);
+
+  virtual void load() = 0;
 
 private:
   const DeviceType type;

--- a/kernel/include/mykonos/drivers/tree.h
+++ b/kernel/include/mykonos/drivers/tree.h
@@ -48,7 +48,11 @@ public:
   };
 
   DeviceTree(DeviceType type) : type(type) {}
-  virtual ~DeviceTree() {}
+  virtual ~DeviceTree() {
+    for (auto &child : *this) {
+      delete &child;
+    }
+  }
 
   DeviceType getType() { return type; }
 


### PR DESCRIPTION
this creates the device tree. The device tree is a tree of the devices in the system and their drivers. This creates the base class for the device tree nodes. The nodes will include the ACPI tables, PCIE configuration and USB devices.