### PR TITLE
Load acpi tree

### DIFF
--- a/kernel/drivers/Make.steps
+++ b/kernel/drivers/Make.steps
@@ -1,2 +1,2 @@
-STEPS+=drivers/tree.o
+STEPS+=drivers/tree.o drivers/acpiTree.o
 STEPS+=drivers/hpet/hpet.o

--- a/kernel/drivers/acpiTree.cpp
+++ b/kernel/drivers/acpiTree.cpp
@@ -15,6 +15,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <mykonos/drivers/acpiTree.h>
+#include <mykonos/kout.h>
 
 namespace drivers {
 struct TableDriver {
@@ -24,13 +25,22 @@ struct TableDriver {
 static TableDriver tableDrivers[] = {};
 
 void AcpiDeviceTree::load() {
+    kout::print("Scanning ACPI tables\n");
+    unsigned unusedTableCount = 0;
   for (size_t i = 0; i < tables->childCount(); i++) {
     acpi::TableManager *table = (*tables)[i];
+    bool used = false;
     for (auto &tableDriver : tableDrivers) {
-        if (tableDriver.type == table->type) {
-          appendAndLoad(tableDriver.get(table));
-        }
+      if (tableDriver.type == table->type) {
+          used = true;
+        appendAndLoad(tableDriver.get(table));
+        break;
+      }
+    }
+    if (!used) {
+        unusedTableCount++;
     }
   }
+  kout::printf("%d unused ACPI tables\n", unusedTableCount);
 }
 } // namespace drivers

--- a/kernel/drivers/acpiTree.cpp
+++ b/kernel/drivers/acpiTree.cpp
@@ -14,24 +14,23 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#ifndef _MYKONOS_DRIVERS_ACPI_TREE_H
-#define _MYKONOS_DRIVERS_ACPI_TREE_H
-
-#include <mykonos/acpi/rsdt.h>
-#include <mykonos/drivers/tree.h>
+#include <mykonos/drivers/acpiTree.h>
 
 namespace drivers {
-class AcpiDeviceTree : public DeviceTree {
-public:
-  AcpiDeviceTree(acpi::RsdtTableManager *tables)
-      : DeviceTree(DeviceType::ACPI), tables(tables) {}
-
-protected:
-  virtual void load();
-
-private:
-  acpi::RsdtTableManager *tables;
+struct TableDriver {
+  acpi::TableType type;
+  DeviceTree *(*get)(acpi::TableManager *);
 };
-} // namespace drivers
+static TableDriver tableDrivers[] = {};
 
-#endif
+void AcpiDeviceTree::load() {
+  for (size_t i = 0; i < tables->childCount(); i++) {
+    acpi::TableManager *table = (*tables)[i];
+    for (auto &tableDriver : tableDrivers) {
+        if (tableDriver.type == table->type) {
+          appendAndLoad(tableDriver.get(table));
+        }
+    }
+  }
+}
+} // namespace drivers

--- a/kernel/drivers/acpiTree.cpp
+++ b/kernel/drivers/acpiTree.cpp
@@ -25,20 +25,20 @@ struct TableDriver {
 static TableDriver tableDrivers[] = {};
 
 void AcpiDeviceTree::load() {
-    kout::print("Scanning ACPI tables\n");
-    unsigned unusedTableCount = 0;
+  kout::print("Scanning ACPI tables\n");
+  unsigned unusedTableCount = 0;
   for (size_t i = 0; i < tables->childCount(); i++) {
     acpi::TableManager *table = (*tables)[i];
     bool used = false;
     for (auto &tableDriver : tableDrivers) {
       if (tableDriver.type == table->type) {
-          used = true;
+        used = true;
         appendAndLoad(tableDriver.get(table));
         break;
       }
     }
     if (!used) {
-        unusedTableCount++;
+      unusedTableCount++;
     }
   }
   kout::printf("%d unused ACPI tables\n", unusedTableCount);

--- a/kernel/drivers/tree.cpp
+++ b/kernel/drivers/tree.cpp
@@ -32,4 +32,9 @@ void DeviceTree::appendAndLoad(DeviceTree *child) {
       },
       (void *)child);
 }
+
+static DeviceTree *rootDevice;
+
+void setRootDevice(DeviceTree *device) { rootDevice = device; }
+void loadRootDevice() { rootDevice->load(); }
 } // namespace drivers

--- a/kernel/include/mykonos/drivers/acpiTree.h
+++ b/kernel/include/mykonos/drivers/acpiTree.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_DRIVERS_ACPI_TREE_H
+#define _MYKONOS_DRIVERS_ACPI_TREE_H
+
+#include <mykonos/acpi/rsdt.h>
+#include <mykonos/drivers/tree.h>
+
+namespace drivers {
+class AcpiDeviceTree : public DeviceTree {
+public:
+  AcpiDeviceTree(acpi::RsdtTableManager tables)
+      : DeviceTree(DeviceType::ACPI), tables(tables) {}
+
+protected:
+  virtual void load();
+
+private:
+  acpi::RsdtTableManager *tables;
+};
+} // namespace drivers
+
+#endif

--- a/kernel/include/mykonos/drivers/tree.h
+++ b/kernel/include/mykonos/drivers/tree.h
@@ -20,6 +20,8 @@
 namespace drivers {
 enum class DeviceType { ACPI };
 
+void loadRootDevice();
+
 class DeviceTree {
 public:
   class Iterator {
@@ -71,7 +73,11 @@ private:
   DeviceTree *lastChild = nullptr;
 
   DeviceTree *next = nullptr;
+
+  friend void loadRootDevice();
 };
+
+void setRootDevice(DeviceTree *device);
 } // namespace drivers
 
 #endif


### PR DESCRIPTION
This establishes the device tree. The root element is the ACPI tree. The ACPI tree loads all of the drivers for tables (of which there are none yet). This is how the hardware initialization will start.