### PR TITLE
Read xhci version

### DIFF
--- a/kernel/drivers/Make.steps
+++ b/kernel/drivers/Make.steps
@@ -1,2 +1,3 @@
 STEPS+=drivers/tree.o drivers/acpiTree.o drivers/pcieTree.o
+STEPS+=drivers/pcie/pcieBars.o
 STEPS+=drivers/hpet/hpet.o

--- a/kernel/drivers/Make.steps
+++ b/kernel/drivers/Make.steps
@@ -1,3 +1,4 @@
 STEPS+=drivers/tree.o drivers/acpiTree.o drivers/pcieTree.o
 STEPS+=drivers/pcie/pcieBars.o
+STEPS+=drivers/usb/xhci/xhciDriver.o
 STEPS+=drivers/hpet/hpet.o

--- a/kernel/drivers/pcie/pcieBars.cpp
+++ b/kernel/drivers/pcie/pcieBars.cpp
@@ -36,10 +36,10 @@ void *PcieDeviceAccess::mapBar(unsigned number) {
     kout::print("BAR not present in memory\n");
     return nullptr;
   }
-  bar &= 0xfffffff0;
   if (number < 5 && PCIE_BAR_TYPE(bar) == PCIE_BAR_64) {
     bar |= (uint64_t)readBar(number + 1) << 32;
   }
+  bar &= ~(uint64_t)0xf;
   // Setting the BAR to ffffffff lets us find the number of bits we can change
   // which tells us the size of the mapped region
   writeBar(number, 0xffffffff);

--- a/kernel/drivers/pcie/pcieBars.cpp
+++ b/kernel/drivers/pcie/pcieBars.cpp
@@ -1,0 +1,50 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/drivers/pcie/pcie.h>
+#include <mykonos/kmalloc.h>
+#include <mykonos/kout.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define PCIE_BAR_MEMORY (1 << 0)
+#define PCIE_BAR_TYPE(BAR) (((BAR)&0x6) >> 1)
+#define PCIE_BAR_64 2
+#define PCIE_BAR_32 0
+
+namespace drivers {
+void *PcieDeviceAccess::mapBar(unsigned number) {
+  if (number > 5) {
+    kout::printf("Invalid BAR number %d\n", number);
+    return nullptr;
+  }
+  uint64_t bar = readBar(number);
+  if ((bar & PCIE_BAR_MEMORY) == 0) {
+    kout::print("BAR not present in memory\n");
+    return nullptr;
+  }
+  bar &= 0xfffffff0;
+  if (number < 5 && PCIE_BAR_TYPE(bar) == PCIE_BAR_64) {
+    bar |= (uint64_t)readBar(number + 1) << 32;
+  }
+  // Setting the BAR to ffffffff lets us find the number of bits we can change
+  // which tells us the size of the mapped region
+  writeBar(number, 0xffffffff);
+  size_t mappedSize = ~(readBar(number) & 0xfffffff0) + 1;
+  writeBar(number, bar & 0xffffffff);
+  return memory::mapAddress((void *)bar, mappedSize, false);
+}
+} // namespace drivers

--- a/kernel/drivers/pcie/pcieBars.cpp
+++ b/kernel/drivers/pcie/pcieBars.cpp
@@ -32,7 +32,7 @@ void *PcieDeviceAccess::mapBar(unsigned number) {
     return nullptr;
   }
   uint64_t bar = readBar(number);
-  if ((bar & PCIE_BAR_MEMORY) == 0) {
+  if ((bar & PCIE_BAR_MEMORY) != 0) {
     kout::print("BAR not present in memory\n");
     return nullptr;
   }

--- a/kernel/drivers/pcieTree.cpp
+++ b/kernel/drivers/pcieTree.cpp
@@ -16,6 +16,7 @@
 */
 #include <mykonos/drivers/pcie/pcie.h>
 #include <mykonos/drivers/pcieTree.h>
+#include <mykonos/drivers/usb/xhci/xhciDriver.h>
 #include <mykonos/kout.h>
 
 #define PCIE_DEVICE(BASE, BUS, DEVICE, FUNCTION)                               \
@@ -37,7 +38,13 @@ struct PcieDriver {
   DeviceTree *(*get)(PcieDeviceAccess);
 };
 
-static PcieDriver pcieDrivers[] = {};
+static DeviceTree *loadXhciDriver(PcieDeviceAccess access) {
+  return new xhci::XhciDriver(
+      xhci::XhciRegisterAccess((xhci::XhciRegisters *)access.mapBar(0)));
+}
+
+static PcieDriver pcieDrivers[] = {
+    {0xffff, 0xffff, 0x0c, 0x03, 0x30, loadXhciDriver}};
 
 void PcieDeviceTree::load() {
   kout::print("Scanning PCIE configuration\n");

--- a/kernel/drivers/pcieTree.cpp
+++ b/kernel/drivers/pcieTree.cpp
@@ -32,6 +32,7 @@ struct PcieDriver {
   // Used if vendorId == 0xffff
   uint8_t classId;
   uint8_t subclass;
+  uint8_t registerInterface; // Used if != 0xff
 
   DeviceTree *(*get)(PcieDeviceAccess);
 };
@@ -59,8 +60,11 @@ void PcieDeviceTree::load() {
                 matched = driver.vendorId == access.getVendorId() &&
                           driver.deviceId == access.getDeviceId();
               } else {
-                matched = driver.classId == access.getClass() &&
-                          driver.subclass == access.getSubclass();
+                matched =
+                    driver.classId == access.getClass() &&
+                    driver.subclass == access.getSubclass() &&
+                    (driver.registerInterface == 0xff ||
+                     driver.registerInterface == access.getRegisterInterface());
               }
               if (matched) {
                 appendAndLoad(driver.get(access));

--- a/kernel/drivers/usb/xhci/xhciDriver.cpp
+++ b/kernel/drivers/usb/xhci/xhciDriver.cpp
@@ -1,0 +1,26 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/drivers/usb/xhci/xhciDriver.h>
+#include <mykonos/kout.h>
+
+namespace drivers {
+namespace xhci {
+void XhciDriver::load() {
+  kout::printf("XHCI version %x\n", registers.getVersion());
+}
+} // namespace xhci
+} // namespace drivers

--- a/kernel/include/mykonos/drivers/pcie/pcie.h
+++ b/kernel/include/mykonos/drivers/pcie/pcie.h
@@ -34,12 +34,7 @@ struct PcieDeviceHeader {
   uint8_t latencyTimer;
   uint8_t headerType;
   uint8_t selfTest;
-  uint32_t bar0;
-  uint32_t bar1;
-  uint32_t bar2;
-  uint32_t bar3;
-  uint32_t bar4;
-  uint32_t bar5;
+  uint32_t bars[6];
 };
 class PcieDeviceAccess {
 public:
@@ -61,8 +56,17 @@ public:
 
   uint8_t getHeaderType() { return mmio::read(&devicePointer->headerType); }
 
+  void *mapBar(unsigned number);
+
 private:
-  const PcieDeviceHeader *devicePointer;
+  uint32_t readBar(unsigned number) {
+    return mmio::read(&devicePointer->bars[number]);
+  }
+  void writeBar(unsigned number, uint32_t value) {
+    mmio::write(&devicePointer->bars[number], value);
+  }
+
+  PcieDeviceHeader *devicePointer;
 };
 } // namespace drivers
 

--- a/kernel/include/mykonos/drivers/tree.h
+++ b/kernel/include/mykonos/drivers/tree.h
@@ -18,7 +18,7 @@
 #define _MYKONOS_DRIVERS_TREE_H
 
 namespace drivers {
-enum class DeviceType { ACPI, PCIE };
+enum class DeviceType { ACPI, PCIE, XHCI };
 
 void loadRootDevice();
 

--- a/kernel/include/mykonos/drivers/usb/xhci/xhciDriver.h
+++ b/kernel/include/mykonos/drivers/usb/xhci/xhciDriver.h
@@ -17,8 +17,6 @@
 #ifndef _MYKONOS_DRIVERS_USB_XHCI_XHCI_DRIVER_H
 #define _MYKONOS_DRIVERS_USB_XHCI_XHCI_DRIVER_H
 
-#include <mykonos/
-
 #include <mykonos/drivers/tree.h>
 #include <mykonos/drivers/usb/xhci/xhciRegisters.h>
 
@@ -26,7 +24,8 @@ namespace drivers {
 namespace xhci {
 class XhciDriver : public DeviceTree {
 public:
-  XhciDriver(XhciRegisterAccess registers) : registers(registers) {}
+  XhciDriver(XhciRegisterAccess registers)
+      : DeviceTree(DeviceType::XHCI), registers(registers) {}
 
   void load();
 

--- a/kernel/include/mykonos/drivers/usb/xhci/xhciDriver.h
+++ b/kernel/include/mykonos/drivers/usb/xhci/xhciDriver.h
@@ -1,0 +1,39 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_DRIVERS_USB_XHCI_XHCI_DRIVER_H
+#define _MYKONOS_DRIVERS_USB_XHCI_XHCI_DRIVER_H
+
+#include <mykonos/
+
+#include <mykonos/drivers/tree.h>
+#include <mykonos/drivers/usb/xhci/xhciRegisters.h>
+
+namespace drivers {
+namespace xhci {
+class XhciDriver : public DeviceTree {
+public:
+  XhciDriver(XhciRegisterAccess registers) : registers(registers) {}
+
+  void load();
+
+private:
+  XhciRegisterAccess registers;
+};
+} // namespace xhci
+} // namespace drivers
+
+#endif

--- a/kernel/include/mykonos/drivers/usb/xhci/xhciRegisters.h
+++ b/kernel/include/mykonos/drivers/usb/xhci/xhciRegisters.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_DRIVERS_USB_XHCI_XHCI_REGISTERS_H
+#define _MYKONOS_DRIVERS_USB_XHCI_XHCI_REGISTERS_H
+
+#include <mykonos/mmio.h>
+
+#include <stdint.h>
+
+namespace drivers {
+namespace xhci {
+struct XhciRegisters {
+  uint8_t capabilityLength;
+  uint8_t reserved0;
+  uint16_t version;
+  // ...
+};
+class XhciRegisterAccess {
+public:
+  XhciRegisterAccess(XhciRegisters *registers) : registers(registers) {}
+  
+  uint8_t getCapabilityLength() {
+    return mmio::read(&registers->capabilityLength);
+  }
+  uint16_t getVersion() { return mmio::read(&registers->version); }
+
+private:
+  XhciRegisters *registers;
+};
+} // namespace xhci
+} // namespace drivers
+
+#endif

--- a/kernel/include/mykonos/drivers/usb/xhci/xhciRegisters.h
+++ b/kernel/include/mykonos/drivers/usb/xhci/xhciRegisters.h
@@ -32,7 +32,7 @@ struct XhciRegisters {
 class XhciRegisterAccess {
 public:
   XhciRegisterAccess(XhciRegisters *registers) : registers(registers) {}
-  
+
   uint8_t getCapabilityLength() {
     return mmio::read(&registers->capabilityLength);
   }


### PR DESCRIPTION
The XHCI controller is the controller controlling the USB protocol. This is the first PCIE device driver implemented. So far it just reads the version field and prints it to the screen.