### PR TITLE
Create safe string iterator

### DIFF
--- a/kernel/include/mykonos/iterator.h
+++ b/kernel/include/mykonos/iterator.h
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_ITERATOR_H
+#define _MYKONOS_ITERATOR_H
+
+#include <stddef.h>
+
+namespace util {
+template <typename T> class RangedIterator {
+public:
+  RangedIterator(T *begin, T *end, T *pointer)
+      : begin(begin), end(end), pointer(pointer) {}
+
+  T &operator[](size_t index) const {
+    return pointer + index < end && pointer + index >= begin ? pointer[index]
+                                                             : {};
+  }
+  T &operator*() { return (*this)[0]; }
+
+  RangedIterator<T> operator++(int) {
+    RangedIterator<T> result = *this;
+    pointer++;
+    return result;
+  }
+  RangedIterator<T> &operator++() {
+    pointer++;
+    return *this;
+  }
+  RangedIterator<T> operator+(size_t offset) const {
+    return {begin, end, pointer + offset};
+  }
+  RangedIterator<T> operator--(int) {
+    RangedIterator<T> result = *this;
+    pointer--;
+    return result;
+  }
+  RangedIterator<T> &operator--() {
+    pointer--;
+    return *this;
+  }
+  RangedIterator<T> operator-(size_t offset) const {
+    return {begin, end, pointer - offset};
+  }
+
+  size_t operator-(const RangedIterator<T> &other) const {
+    if (other.begin == begin && other.end == end) {
+      return pointer - other.pointer;
+    } else {
+      return -1;
+    }
+  }
+
+  bool operator==(const RangedIterator<T> &other) const {
+    return other.begin == begin && other.end == end && other.pointer == pointer;
+  }
+  bool operator!=(const RangedIterator<T> &other) const {
+    return !((*this) == other);
+  }
+
+private:
+  T *begin;
+  T *end;
+  T *pointer;
+};
+} // namespace util
+
+#endif

--- a/kernel/include/mykonos/iterator.h
+++ b/kernel/include/mykonos/iterator.h
@@ -27,7 +27,7 @@ public:
 
   T &operator[](size_t index) const {
     return pointer + index < end && pointer + index >= begin ? pointer[index]
-                                                             : {};
+                                                             : T{};
   }
   T &operator*() { return (*this)[0]; }
 

--- a/kernel/include/mykonos/iterator.h
+++ b/kernel/include/mykonos/iterator.h
@@ -25,7 +25,9 @@ public:
   RangedIterator(T *begin, T *end, T *pointer)
       : begin(begin), end(end), pointer(pointer) {}
 
-  T &operator[](size_t index) const {
+  using DiffType = ptrdiff_t;
+
+  T &operator[](DiffType index) const {
     return pointer + index < end && pointer + index >= begin ? pointer[index]
                                                              : T{};
   }
@@ -40,7 +42,7 @@ public:
     pointer++;
     return *this;
   }
-  RangedIterator<T> operator+(size_t offset) const {
+  RangedIterator<T> operator+(DiffType offset) const {
     return {begin, end, pointer + offset};
   }
   RangedIterator<T> operator--(int) {
@@ -52,11 +54,11 @@ public:
     pointer--;
     return *this;
   }
-  RangedIterator<T> operator-(size_t offset) const {
+  RangedIterator<T> operator-(DiffType offset) const {
     return {begin, end, pointer - offset};
   }
 
-  size_t operator-(const RangedIterator<T> &other) const {
+  DiffType operator-(const RangedIterator<T> &other) const {
     if (other.begin == begin && other.end == end) {
       return pointer - other.pointer;
     } else {

--- a/kernel/include/mykonos/string.h
+++ b/kernel/include/mykonos/string.h
@@ -17,6 +17,7 @@
 #ifndef _MYKONOS_STRING_H
 #define _MYKONOS_STRING_H
 
+#include <mykonos/iterator.h>
 #include <stddef.h>
 
 extern "C" {
@@ -47,10 +48,10 @@ public:
     return index < length ? cString[index] : 0;
   }
 
-  using Iterator = const char *;
+  using Iterator = util::RangedIterator<const char>;
 
-  Iterator begin() const { return cString; }
-  Iterator end() const { return cString + length; }
+  Iterator begin() const { return {cString, cString + length, cString}; }
+  Iterator end() const { return {cString, cString + length, cString + length}; }
 
   String subString(size_t begin, size_t end) const {
     if (begin > length || begin > end) {
@@ -76,7 +77,7 @@ public:
     if (match == nullptr) {
       return {};
     } else {
-      return String(match, end() - match);
+      return String(match, cString + length - match);
     }
   }
 


### PR DESCRIPTION
The String::Iterator type used to be a const char *. This meant that it was possible to access the underlying cString. Now, however, the Iterator type is a RangedIterator type which checks if the accesses are within the range of the string, thus making the String type much safer.