### PR TITLE
Wait for hardware initialization

### DIFF
--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -233,6 +233,7 @@ static bool hardwareInitLock = 0;
   if (__sync_bool_compare_and_swap(&hardwareInitLock, 0, 1)) {
     kout::print("Starting hardware initialization\n");
     drivers::loadRootDevice();
+    kout::print("Finished hardware initialization\n");
   }
   thread::destroy();
 }

--- a/kernel/include/mykonos/async/completion.h
+++ b/kernel/include/mykonos/async/completion.h
@@ -1,0 +1,36 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_ASYNC_COMPLETION_H
+#define _MYKONOS_ASYNC_COMPLETION_H
+
+#include <mykonos/spinlock.h>
+#include <mykonos/task/taskQueue.h>
+
+namespace async {
+class Completion {
+public:
+  void signalComplete();
+  void await();
+
+private:
+  lock::Spinlock lock;
+  task::Queue waitingTasks;
+  bool completed = false;
+};
+} // namespace async
+
+#endif

--- a/kernel/include/mykonos/drivers/tree.h
+++ b/kernel/include/mykonos/drivers/tree.h
@@ -17,6 +17,8 @@
 #ifndef _MYKONOS_DRIVERS_TREE_H
 #define _MYKONOS_DRIVERS_TREE_H
 
+#include <mykonos/async/completion.h>
+
 namespace drivers {
 enum class DeviceType { ACPI, PCIE, XHCI };
 
@@ -68,11 +70,14 @@ protected:
 
 private:
   const DeviceType type;
+  async::Completion initializationCompletion;
 
   DeviceTree *firstChild = nullptr;
   DeviceTree *lastChild = nullptr;
 
   DeviceTree *next = nullptr;
+
+  void loadAndWait();
 
   friend void loadRootDevice();
 };

--- a/kernel/scheduler/Make.steps
+++ b/kernel/scheduler/Make.steps
@@ -1,2 +1,3 @@
-STEPS+=scheduler/scheduler.o scheduler/mutex.o
+STEPS+=scheduler/scheduler.o
+STEPS+=scheduler/mutex.o scheduler/completion.o
 TEST_STEPS+=scheduler/taskQueue_test.o

--- a/kernel/scheduler/completion.cpp
+++ b/kernel/scheduler/completion.cpp
@@ -1,0 +1,43 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include <mykonos/async/completion.h>
+#include <mykonos/scheduler.h>
+
+namespace async {
+void Completion::await() {
+  lock.acquire();
+  if (completed) {
+    lock.release();
+  } else {
+    waitingTasks.push(scheduler::block());
+    lock.release();
+    scheduler::yield();
+  }
+}
+void Completion::signalComplete() {
+  lock.acquire();
+  completed = true;
+  auto nextTask = waitingTasks.pop();
+  scheduler::lock();
+  while (nextTask != nullptr) {
+    scheduler::addTask(nextTask);
+    nextTask = waitingTasks.pop();
+  }
+  scheduler::unlock();
+  lock.release();
+}
+} // namespace async


### PR DESCRIPTION
The drivers::loadRootDevice function used to return as soon as the root device's load() method completed. This meant that it was impossible to carry on with any other tasks after hardware initialization while knowing that hardware initialization was completed.

Now the initialization threads signal up the chain when they finish so the loadRootDevice function can wait for the root device to complete before returning.