### PR TITLE
Preserve smp trampoline location

### DIFF
--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -155,7 +155,9 @@ extern "C" [[noreturn]] void kstart() {
       }
       memcpy(smpTrampolineDestination, previousTrampolineContents,
              smpTrampolineSize);
-      memory::unmapMemory(smpTrampolineDestination, 0x1000);
+      // We can't unmap anything just now due to TLB shootdown
+      cleaner::addObject(smpTrampolineDestination,
+                         [](void *ptr) { memory::unmapMemory(ptr, 0x1000); });
     }
     // Store our CPU number (0 for BSP)
     cpu::setCpuNumber(0);

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -129,8 +129,10 @@ extern "C" [[noreturn]] void kstart() {
           memory::mapAddress((void *)0x8000, 0x1000, false);
       size_t smpTrampolineSize =
           (size_t)&smpTrampolineEnd - (size_t)&smpTrampolineStart;
+      uint8_t previousTrampolineContents[smpTrampolineSize];
+      memcpy(previousTrampolineContents, smpTrampolineDestination,
+             smpTrampolineSize);
       memcpy(smpTrampolineDestination, &smpTrampolineStart, smpTrampolineSize);
-      memory::unmapMemory(smpTrampolineDestination, 0x1000);
       smp::allocateStacks(madt->localApicCount());
       kout::print("Beginning SMP initialization\n");
       uint8_t myApicId = apic::localApic.getApicId();
@@ -151,6 +153,9 @@ extern "C" [[noreturn]] void kstart() {
           apic::localApicIds[0] = apicId;
         }
       }
+      memcpy(smpTrampolineDestination, previousTrampolineContents,
+             smpTrampolineSize);
+      memory::unmapMemory(smpTrampolineDestination, 0x1000);
     }
     // Store our CPU number (0 for BSP)
     cpu::setCpuNumber(0);


### PR DESCRIPTION
The SMP trampoline used to just overwrite the area at 0x8000. This is not good and could result in bad things happening in future.

Now the kernel puts the original contents of that memory location back after the SMP trampolining is over.