### PR TITLE
Create initramfs image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ isoimage: kernel initramfs build/boot.efi
 	@mkdir -p build/isoroot
 	@mkdir -p build/isoroot/boot/grub
 	@cp build/mykonos build/isoroot/boot/mykonos
-	@cp build/initramfs.img built/isoroot/boot/initramfs.img
+	@cp build/initramfs.img build/isoroot/boot/initramfs.img
 	@cp grub/example.cfg build/isoroot/boot/grub/grub.cfg
 	@mkdir -p build/isoroot/EFI/BOOT
 	@cp build/boot.efi build/isoroot/EFI/BOOT/$(EFI_FILE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export ASFLAGS:=
 
 export LDFLAGS:=-nostdlib -Wl,--gc-sections
 
-all: check-dependencies kernel
+all: check-dependencies isoimage
 
 .PHONY: check-dependencies
 check-dependencies:
@@ -39,16 +39,24 @@ kernel: kernel/Makefile
 	@objcopy --only-keep-debug build/mykonos build/mykonos.debug
 	@strip --strip-all build/mykonos
 
+.PHONY: initramfs
+initramfs:
+	@mkdir -p build/initramfs
+	@cp -RT config/ build/initramfs/
+	@echo build build/initramfs.img
+	@tar -C build/initramfs -cf build/initramfs.img .
+
 EFI_FILE_NAME?=BOOTX64.EFI
 
 build/boot.efi:
 	@grub-mkimage -O $(ARCH)-efi -p /boot/grub -o $@ normal part_msdos fat iso9660 part_gpt all_video multiboot2
 
 .PHONY: isoimage
-isoimage: all build/boot.efi
+isoimage: kernel initramfs build/boot.efi
 	@mkdir -p build/isoroot
 	@mkdir -p build/isoroot/boot/grub
 	@cp build/mykonos build/isoroot/boot/mykonos
+	@cp build/initramfs.img built/isoroot/boot/initramfs.img
 	@cp grub/example.cfg build/isoroot/boot/grub/grub.cfg
 	@mkdir -p build/isoroot/EFI/BOOT
 	@cp build/boot.efi build/isoroot/EFI/BOOT/$(EFI_FILE_NAME)

--- a/config/test.txt
+++ b/config/test.txt
@@ -1,0 +1,1 @@
+This is a test file to go into the initramfs!

--- a/grub/example.cfg
+++ b/grub/example.cfg
@@ -3,5 +3,6 @@ set default=0
 
 menuentry "mykonos" {
 	multiboot2 /boot/mykonos
+	module2 /boot/initramfs.img
 	boot
 }


### PR DESCRIPTION
The initramfs is an important thing. It allows the kernel to run programs and load modules and so on before the disk drivers are ready.

This creates the initramfs image with a test file in it for now.