### PR TITLE
Parse mbi module tag

### DIFF
--- a/kernel/arch/x86_64/include/mykonos/mbi.h
+++ b/kernel/arch/x86_64/include/mykonos/mbi.h
@@ -26,10 +26,20 @@ struct MbiTag {
   uint32_t type;
   uint32_t size;
 };
+#define MBI_TAG_MODULE 3
 #define MBI_TAG_MEMORY 6
 #define MBI_TAG_FRAME_BUFFER 8
 #define MBI_TAG_RSDP_OLD 14
 #define MBI_TAG_RSDP_NEW 15
+
+struct ModuleTag {
+  uint32_t type;
+  uint32_t size;
+  uint32_t moduleStart;
+  uint32_t moduleEnd;
+  char string[0];
+};
+static_assert(sizeof(ModuleTag) == 16, "ModuleTag has incorrect size");
 
 struct MemoryMapTag {
   uint32_t type;

--- a/kernel/arch/x86_64/kernel/mbi.cpp
+++ b/kernel/arch/x86_64/kernel/mbi.cpp
@@ -49,6 +49,14 @@ void parseMbi() {
     parseMbiTag(tag->type, tag);
     tag = (MbiTag *)((uint8_t *)tag + (tag->size + 7) / 8 * 8);
   }
+  // Now that the module and memory map tags are parsed, we should reserve the
+  // initramfs from the physical memory map.
+  auto &initramfs = initramfs::initramfs;
+  if (initramfs.size > 0) {
+    memory::physicalMemory.reserve(
+        {(void *)PAGE_ALIGN_DOWN((size_t)initramfs.pointer),
+         (void *)PAGE_ALIGN_UP((size_t)initramfs.pointer + initramfs.size)});
+  }
 }
 static void parseModuleTag(ModuleTag *tag);
 static void parseMemoryMapTag(MemoryMapTag *memoryMap);

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -69,8 +69,10 @@ extern "C" [[noreturn]] void kstart() {
   multiboot::parseMbi();
   paging::initPageTables();
   // Now that paging is enabled, we must map in the initramfs.
-  initramfs::initramfs.pointer = memory::mapAddress(
-      initramfs::initramfs.pointer, initramfs::initramfs.size, true);
+  if (initramfs::initramfs.size > 0) {
+    initramfs::initramfs.pointer = memory::mapAddress(
+        initramfs::initramfs.pointer, initramfs::initramfs.size, true);
+  }
   display::initFrameBuffer();
   interrupts::init();
   interrupts::install();

--- a/kernel/arch/x86_64/kernel/startup.cpp
+++ b/kernel/arch/x86_64/kernel/startup.cpp
@@ -27,6 +27,7 @@
 #include <mykonos/drivers/tree.h>
 #include <mykonos/frameBuffer.h>
 #include <mykonos/hpet.h>
+#include <mykonos/initramfs.h>
 #include <mykonos/interrupts.h>
 #include <mykonos/kmalloc.h>
 #include <mykonos/kout.h>
@@ -67,6 +68,9 @@ extern "C" [[noreturn]] void kstart() {
   // Now that that's over
   multiboot::parseMbi();
   paging::initPageTables();
+  // Now that paging is enabled, we must map in the initramfs.
+  initramfs::initramfs.pointer = memory::mapAddress(
+      initramfs::initramfs.pointer, initramfs::initramfs.size, true);
   display::initFrameBuffer();
   interrupts::init();
   interrupts::install();

--- a/kernel/include/mykonos/initramfs.h
+++ b/kernel/include/mykonos/initramfs.h
@@ -1,0 +1,30 @@
+/*
+    Copyright (C) 2022 Jett Thompson
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#ifndef _MYKONOS_INITRAMFS_H
+#define _MYKONOS_INITRAMFS_H
+
+#include <stddef.h>
+
+namespace initramfs {
+struct Initramfs {
+  void *pointer;
+  size_t size;
+};
+extern Initramfs initramfs;
+} // namespace initramfs
+
+#endif


### PR DESCRIPTION
This makes the kernel map the initramfs module from grub into virtual memory and store a pointer to it for use later. This can be used later for the initramfs FsProvider implementation.